### PR TITLE
[feat] Dropdown 공통 컴포넌트 구현

### DIFF
--- a/packages/ui/src/components/shadcn/dropdown-menu.tsx
+++ b/packages/ui/src/components/shadcn/dropdown-menu.tsx
@@ -1,0 +1,235 @@
+import { cn } from "@ui/lib/utils";
+import { CheckIcon, ChevronRightIcon } from "lucide-react";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+import type * as React from "react";
+
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+}
+
+function DropdownMenuTrigger({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn("px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({ className, ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};

--- a/packages/ui/src/components/shadcn/select.tsx
+++ b/packages/ui/src/components/shadcn/select.tsx
@@ -1,0 +1,166 @@
+import { cn } from "@ui/lib/utils";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { Select as SelectPrimitive } from "radix-ui";
+import type * as React from "react";
+
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" className={cn("scroll-my-1 p-1", className)} {...props} />;
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        data-align-trigger={position === "item-aligned"}
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className,
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          data-position={position}
+          className={cn(
+            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
+            position === "popper" && "",
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="pointer-events-none" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "z-10 flex cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/packages/ui/src/components/stories/dropdown.stories.tsx
+++ b/packages/ui/src/components/stories/dropdown.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "@ui/components/ui/button";
+import { Dropdown } from "@ui/components/ui/dropdown";
+import { EllipsisIcon, ListFilterIcon } from "lucide-react";
+
+const meta = {
+  title: "components/dropdown",
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Dropdown
+      trigger={
+        <Button variant="ghost" type="button">
+          <ListFilterIcon />
+          마감임박
+        </Button>
+      }
+    >
+      <Dropdown.Item onSelect={() => console.log("마감임박")}>마감임박</Dropdown.Item>
+      <Dropdown.Item onSelect={() => console.log("참여인원순")}>참여인원순</Dropdown.Item>
+    </Dropdown>
+  ),
+};
+
+export const IconOnly: Story = {
+  render: () => (
+    <Dropdown
+      trigger={
+        <Button variant="ghost" size="icon-lg" type="button" aria-label="메뉴">
+          <EllipsisIcon />
+        </Button>
+      }
+    >
+      <Dropdown.Item onSelect={() => console.log("수정")}>수정하기</Dropdown.Item>
+      <Dropdown.Item onSelect={() => console.log("삭제")}>삭제하기</Dropdown.Item>
+    </Dropdown>
+  ),
+};
+
+export const AllCases: Story = {
+  render: () => (
+    <div className="flex items-center gap-8">
+      <Dropdown
+        trigger={
+          <Button variant="ghost" type="button">
+            <ListFilterIcon />
+            마감임박
+          </Button>
+        }
+      >
+        <Dropdown.Item>마감임박</Dropdown.Item>
+        <Dropdown.Item>참여인원순</Dropdown.Item>
+      </Dropdown>
+
+      <Dropdown
+        trigger={
+          <Button variant="ghost" size="icon-lg" type="button" aria-label="메뉴">
+            <EllipsisIcon />
+          </Button>
+        }
+      >
+        <Dropdown.Item>수정하기</Dropdown.Item>
+        <Dropdown.Item>삭제하기</Dropdown.Item>
+      </Dropdown>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/stories/dropdown.stories.tsx
+++ b/packages/ui/src/components/stories/dropdown.stories.tsx
@@ -16,31 +16,33 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => (
-    <Dropdown
-      trigger={
+    <Dropdown>
+      <Dropdown.Trigger>
         <Button variant="ghost" type="button">
           <ListFilterIcon />
           마감임박
         </Button>
-      }
-    >
-      <Dropdown.Item onSelect={() => console.log("마감임박")}>마감임박</Dropdown.Item>
-      <Dropdown.Item onSelect={() => console.log("참여인원순")}>참여인원순</Dropdown.Item>
+      </Dropdown.Trigger>
+      <Dropdown.Content>
+        <Dropdown.Item onSelect={() => console.log("마감임박")}>마감임박</Dropdown.Item>
+        <Dropdown.Item onSelect={() => console.log("참여인원순")}>참여인원순</Dropdown.Item>
+      </Dropdown.Content>
     </Dropdown>
   ),
 };
 
 export const IconOnly: Story = {
   render: () => (
-    <Dropdown
-      trigger={
+    <Dropdown>
+      <Dropdown.Trigger>
         <Button variant="ghost" size="icon-lg" type="button" aria-label="메뉴">
           <EllipsisIcon />
         </Button>
-      }
-    >
-      <Dropdown.Item onSelect={() => console.log("수정")}>수정하기</Dropdown.Item>
-      <Dropdown.Item onSelect={() => console.log("삭제")}>삭제하기</Dropdown.Item>
+      </Dropdown.Trigger>
+      <Dropdown.Content>
+        <Dropdown.Item onSelect={() => console.log("수정")}>수정하기</Dropdown.Item>
+        <Dropdown.Item onSelect={() => console.log("삭제")}>삭제하기</Dropdown.Item>
+      </Dropdown.Content>
     </Dropdown>
   ),
 };
@@ -48,27 +50,29 @@ export const IconOnly: Story = {
 export const AllCases: Story = {
   render: () => (
     <div className="flex items-center gap-8">
-      <Dropdown
-        trigger={
+      <Dropdown>
+        <Dropdown.Trigger>
           <Button variant="ghost" type="button">
             <ListFilterIcon />
             마감임박
           </Button>
-        }
-      >
-        <Dropdown.Item>마감임박</Dropdown.Item>
-        <Dropdown.Item>참여인원순</Dropdown.Item>
+        </Dropdown.Trigger>
+        <Dropdown.Content>
+          <Dropdown.Item>마감임박</Dropdown.Item>
+          <Dropdown.Item>참여인원순</Dropdown.Item>
+        </Dropdown.Content>
       </Dropdown>
 
-      <Dropdown
-        trigger={
+      <Dropdown>
+        <Dropdown.Trigger>
           <Button variant="ghost" size="icon-lg" type="button" aria-label="메뉴">
             <EllipsisIcon />
           </Button>
-        }
-      >
-        <Dropdown.Item>수정하기</Dropdown.Item>
-        <Dropdown.Item>삭제하기</Dropdown.Item>
+        </Dropdown.Trigger>
+        <Dropdown.Content>
+          <Dropdown.Item>수정하기</Dropdown.Item>
+          <Dropdown.Item>삭제하기</Dropdown.Item>
+        </Dropdown.Content>
       </Dropdown>
     </div>
   ),

--- a/packages/ui/src/components/stories/selectbox.stories.tsx
+++ b/packages/ui/src/components/stories/selectbox.stories.tsx
@@ -3,42 +3,39 @@ import { SelectBox } from "@ui/components/ui/selectbox";
 
 const meta = {
   title: "components/select-box",
-  component: SelectBox,
   parameters: {
     layout: "centered",
   },
   tags: ["autodocs"],
-  argTypes: {
-    placeholder: {
-      control: "text",
-    },
-  },
-  args: {
-    placeholder: "지역을 선택하세요",
-  },
-} satisfies Meta<typeof SelectBox>;
+} satisfies Meta;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  render: (args) => (
-    <SelectBox {...args}>
-      <SelectBox.Item value="all">지역 전체</SelectBox.Item>
-      <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
-      <SelectBox.Item value="euljiro">을지로 3가</SelectBox.Item>
-      <SelectBox.Item value="sillim">신림</SelectBox.Item>
-      <SelectBox.Item value="hongdae">홍대입구</SelectBox.Item>
+  render: () => (
+    <SelectBox>
+      <SelectBox.Trigger placeholder="지역을 선택하세요" />
+      <SelectBox.Content>
+        <SelectBox.Item value="all">지역 전체</SelectBox.Item>
+        <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
+        <SelectBox.Item value="euljiro">을지로 3가</SelectBox.Item>
+        <SelectBox.Item value="sillim">신림</SelectBox.Item>
+        <SelectBox.Item value="hongdae">홍대입구</SelectBox.Item>
+      </SelectBox.Content>
     </SelectBox>
   ),
 };
 
 export const WithDefaultValue: Story = {
   render: () => (
-    <SelectBox placeholder="지역을 선택하세요" defaultValue="konkuk">
-      <SelectBox.Item value="all">지역 전체</SelectBox.Item>
-      <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
-      <SelectBox.Item value="euljiro">을지로 3가</SelectBox.Item>
+    <SelectBox defaultValue="konkuk">
+      <SelectBox.Trigger placeholder="지역을 선택하세요" />
+      <SelectBox.Content>
+        <SelectBox.Item value="all">지역 전체</SelectBox.Item>
+        <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
+        <SelectBox.Item value="euljiro">을지로 3가</SelectBox.Item>
+      </SelectBox.Content>
     </SelectBox>
   ),
 };
@@ -46,15 +43,22 @@ export const WithDefaultValue: Story = {
 export const AllCases: Story = {
   render: () => (
     <div className="flex flex-col gap-8">
-      <SelectBox placeholder="지역을 선택하세요">
-        <SelectBox.Item value="all">지역 전체</SelectBox.Item>
-        <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
-        <SelectBox.Item value="hongdae">홍대입구</SelectBox.Item>
+      <SelectBox>
+        <SelectBox.Trigger placeholder="지역을 선택하세요" />
+        <SelectBox.Content>
+          <SelectBox.Item value="all">지역 전체</SelectBox.Item>
+          <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
+          <SelectBox.Item value="hongdae">홍대입구</SelectBox.Item>
+        </SelectBox.Content>
       </SelectBox>
 
-      <SelectBox placeholder="카테고리 선택" triggerClassName="max-w-60">
-        <SelectBox.Item value="study">스터디</SelectBox.Item>
-        <SelectBox.Item value="project">프로젝트</SelectBox.Item>
+      <SelectBox defaultValue="konkuk">
+        <SelectBox.Trigger placeholder="지역을 선택하세요" />
+        <SelectBox.Content>
+          <SelectBox.Item value="all">지역 전체</SelectBox.Item>
+          <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
+          <SelectBox.Item value="euljiro">을지로 3가</SelectBox.Item>
+        </SelectBox.Content>
       </SelectBox>
     </div>
   ),

--- a/packages/ui/src/components/stories/selectbox.stories.tsx
+++ b/packages/ui/src/components/stories/selectbox.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SelectBox } from "@ui/components/ui/selectbox";
+
+const meta = {
+  title: "components/select-box",
+  component: SelectBox,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    placeholder: {
+      control: "text",
+    },
+  },
+  args: {
+    placeholder: "지역을 선택하세요",
+  },
+} satisfies Meta<typeof SelectBox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <SelectBox {...args}>
+      <SelectBox.Item value="all">지역 전체</SelectBox.Item>
+      <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
+      <SelectBox.Item value="euljiro">을지로 3가</SelectBox.Item>
+      <SelectBox.Item value="sillim">신림</SelectBox.Item>
+      <SelectBox.Item value="hongdae">홍대입구</SelectBox.Item>
+    </SelectBox>
+  ),
+};
+
+export const WithDefaultValue: Story = {
+  render: () => (
+    <SelectBox placeholder="지역을 선택하세요" defaultValue="konkuk">
+      <SelectBox.Item value="all">지역 전체</SelectBox.Item>
+      <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
+      <SelectBox.Item value="euljiro">을지로 3가</SelectBox.Item>
+    </SelectBox>
+  ),
+};
+
+export const AllCases: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <SelectBox placeholder="지역을 선택하세요">
+        <SelectBox.Item value="all">지역 전체</SelectBox.Item>
+        <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
+        <SelectBox.Item value="hongdae">홍대입구</SelectBox.Item>
+      </SelectBox>
+
+      <SelectBox placeholder="카테고리 선택" triggerClassName="max-w-60">
+        <SelectBox.Item value="study">스터디</SelectBox.Item>
+        <SelectBox.Item value="project">프로젝트</SelectBox.Item>
+      </SelectBox>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/ui/dropdown.tsx
+++ b/packages/ui/src/components/ui/dropdown.tsx
@@ -24,7 +24,10 @@ const DropdownBase = ({ trigger, children, contentClassName }: DropdownProps) =>
 
 const DropdownItem = ({ children, className, ...props }: DropdownItemProps) => {
   return (
-    <Shadcn.DropdownMenuItem className={cn("rounded-lg py-1.5 text-sm font-medium", className)} {...props}>
+    <Shadcn.DropdownMenuItem
+      className={cn("rounded-lg py-1 sm:py-1.5 text-sm sm:text-base font-medium", className)}
+      {...props}
+    >
       {children}
     </Shadcn.DropdownMenuItem>
   );

--- a/packages/ui/src/components/ui/dropdown.tsx
+++ b/packages/ui/src/components/ui/dropdown.tsx
@@ -15,7 +15,7 @@ const DropdownBase = ({ trigger, children, contentClassName }: DropdownProps) =>
   return (
     <Shadcn.DropdownMenu>
       <Shadcn.DropdownMenuTrigger asChild>{trigger}</Shadcn.DropdownMenuTrigger>
-      <Shadcn.DropdownMenuContent className={cn("min-w-27.5 space-y-2 shadow-xl rounded-xl", contentClassName)}>
+      <Shadcn.DropdownMenuContent className={cn("min-w-[110px] space-y-2 shadow-xl rounded-xl", contentClassName)}>
         {children}
       </Shadcn.DropdownMenuContent>
     </Shadcn.DropdownMenu>

--- a/packages/ui/src/components/ui/dropdown.tsx
+++ b/packages/ui/src/components/ui/dropdown.tsx
@@ -4,7 +4,9 @@ import { cn } from "@ui/lib/utils";
 import type * as React from "react";
 
 type DropdownProps = React.ComponentProps<typeof Shadcn.DropdownMenu>;
-type DropdownTriggerProps = React.ComponentProps<typeof Shadcn.DropdownMenuTrigger>;
+type DropdownTriggerProps = Omit<React.ComponentProps<typeof Shadcn.DropdownMenuTrigger>, "children"> & {
+  children: React.ReactElement;
+};
 type DropdownContentProps = React.ComponentProps<typeof Shadcn.DropdownMenuContent>;
 type DropdownItemProps = React.ComponentProps<typeof Shadcn.DropdownMenuItem>;
 

--- a/packages/ui/src/components/ui/dropdown.tsx
+++ b/packages/ui/src/components/ui/dropdown.tsx
@@ -9,7 +9,7 @@ interface DropdownProps {
   contentClassName?: string;
 }
 
-type DropdownItemProps = React.ComponentPropsWithoutRef<typeof Shadcn.DropdownMenuItem>;
+type DropdownItemProps = React.ComponentProps<typeof Shadcn.DropdownMenuItem>;
 
 const DropdownBase = ({ trigger, children, contentClassName }: DropdownProps) => {
   return (

--- a/packages/ui/src/components/ui/dropdown.tsx
+++ b/packages/ui/src/components/ui/dropdown.tsx
@@ -1,0 +1,35 @@
+"use client";
+import * as Shadcn from "@ui/components/shadcn/dropdown-menu";
+import { cn } from "@ui/lib/utils";
+import type * as React from "react";
+
+interface DropdownProps {
+  trigger: React.ReactNode;
+  children: React.ReactNode;
+  contentClassName?: string;
+}
+
+type DropdownItemProps = React.ComponentPropsWithoutRef<typeof Shadcn.DropdownMenuItem>;
+
+const DropdownBase = ({ trigger, children, contentClassName }: DropdownProps) => {
+  return (
+    <Shadcn.DropdownMenu>
+      <Shadcn.DropdownMenuTrigger asChild>{trigger}</Shadcn.DropdownMenuTrigger>
+      <Shadcn.DropdownMenuContent className={cn("min-w-27.5 space-y-2 shadow-xl rounded-xl", contentClassName)}>
+        {children}
+      </Shadcn.DropdownMenuContent>
+    </Shadcn.DropdownMenu>
+  );
+};
+
+const DropdownItem = ({ children, className, ...props }: DropdownItemProps) => {
+  return (
+    <Shadcn.DropdownMenuItem className={cn("rounded-lg py-1.5 text-sm font-medium", className)} {...props}>
+      {children}
+    </Shadcn.DropdownMenuItem>
+  );
+};
+
+export const Dropdown = Object.assign(DropdownBase, {
+  Item: DropdownItem,
+});

--- a/packages/ui/src/components/ui/dropdown.tsx
+++ b/packages/ui/src/components/ui/dropdown.tsx
@@ -3,22 +3,28 @@ import * as Shadcn from "@ui/components/shadcn/dropdown-menu";
 import { cn } from "@ui/lib/utils";
 import type * as React from "react";
 
-interface DropdownProps {
-  trigger: React.ReactNode;
-  children: React.ReactNode;
-  contentClassName?: string;
-}
-
+type DropdownProps = React.ComponentProps<typeof Shadcn.DropdownMenu>;
+type DropdownTriggerProps = React.ComponentProps<typeof Shadcn.DropdownMenuTrigger>;
+type DropdownContentProps = React.ComponentProps<typeof Shadcn.DropdownMenuContent>;
 type DropdownItemProps = React.ComponentProps<typeof Shadcn.DropdownMenuItem>;
 
-const DropdownBase = ({ trigger, children, contentClassName }: DropdownProps) => {
+const DropdownBase = ({ children, ...props }: DropdownProps) => {
+  return <Shadcn.DropdownMenu {...props}>{children}</Shadcn.DropdownMenu>;
+};
+
+const DropdownTrigger = ({ children, ...props }: DropdownTriggerProps) => {
   return (
-    <Shadcn.DropdownMenu>
-      <Shadcn.DropdownMenuTrigger asChild>{trigger}</Shadcn.DropdownMenuTrigger>
-      <Shadcn.DropdownMenuContent className={cn("min-w-[110px] space-y-2 shadow-xl rounded-xl", contentClassName)}>
-        {children}
-      </Shadcn.DropdownMenuContent>
-    </Shadcn.DropdownMenu>
+    <Shadcn.DropdownMenuTrigger asChild {...props}>
+      {children}
+    </Shadcn.DropdownMenuTrigger>
+  );
+};
+
+const DropdownContent = ({ children, className, ...props }: DropdownContentProps) => {
+  return (
+    <Shadcn.DropdownMenuContent className={cn("min-w-[110px] space-y-2 shadow-xl rounded-xl", className)} {...props}>
+      {children}
+    </Shadcn.DropdownMenuContent>
   );
 };
 
@@ -34,5 +40,7 @@ const DropdownItem = ({ children, className, ...props }: DropdownItemProps) => {
 };
 
 export const Dropdown = Object.assign(DropdownBase, {
+  Trigger: DropdownTrigger,
+  Content: DropdownContent,
   Item: DropdownItem,
 });

--- a/packages/ui/src/components/ui/selectbox.tsx
+++ b/packages/ui/src/components/ui/selectbox.tsx
@@ -1,0 +1,54 @@
+"use client";
+import * as Shadcn from "@ui/components/shadcn/select";
+import { cn } from "@ui/lib/utils";
+import { ChevronDown } from "lucide-react";
+import type * as React from "react";
+
+interface SelectBoxProps extends React.ComponentProps<typeof Shadcn.Select> {
+  placeholder?: string;
+  icon?: React.ReactNode;
+  triggerClassName?: string;
+  contentClassName?: string;
+}
+
+type SelectBoxItemProps = React.ComponentProps<typeof Shadcn.SelectItem>;
+
+const SelectBoxBase = ({
+  placeholder,
+  children,
+  icon,
+  triggerClassName,
+  contentClassName,
+  ...props
+}: SelectBoxProps) => {
+  return (
+    <Shadcn.Select {...props}>
+      <Shadcn.SelectTrigger className={cn("group min-h-12 p-3 text-base rounded-xl [&>svg]:hidden", triggerClassName)}>
+        <Shadcn.SelectValue placeholder={placeholder} />
+        <span className="inline-flex items-center justify-center transition-transform group-data-[state=open]:rotate-180">
+          {icon ?? <ChevronDown />}
+        </span>
+      </Shadcn.SelectTrigger>
+
+      <Shadcn.SelectContent
+        position="popper"
+        sideOffset={4}
+        className={cn("space-y-2 shadow-xl rounded-xl", contentClassName)}
+      >
+        <Shadcn.SelectGroup>{children}</Shadcn.SelectGroup>
+      </Shadcn.SelectContent>
+    </Shadcn.Select>
+  );
+};
+
+const SelectBoxItem = ({ children, className, ...props }: SelectBoxItemProps) => {
+  return (
+    <Shadcn.SelectItem className={cn("rounded-lg py-3 pl-3 text-base font-medium", className)} {...props}>
+      {children}
+    </Shadcn.SelectItem>
+  );
+};
+
+export const SelectBox = Object.assign(SelectBoxBase, {
+  Item: SelectBoxItem,
+});

--- a/packages/ui/src/components/ui/selectbox.tsx
+++ b/packages/ui/src/components/ui/selectbox.tsx
@@ -23,7 +23,9 @@ const SelectBoxBase = ({
 }: SelectBoxProps) => {
   return (
     <Shadcn.Select {...props}>
-      <Shadcn.SelectTrigger className={cn("group min-h-12 p-3 text-base rounded-xl [&>svg]:hidden", triggerClassName)}>
+      <Shadcn.SelectTrigger
+        className={cn("group py-2 min-h-11 sm:p-3 sm:min-h-12 text-base rounded-xl [&>svg]:hidden", triggerClassName)}
+      >
         <Shadcn.SelectValue placeholder={placeholder} />
         <span className="inline-flex items-center justify-center transition-transform group-data-[state=open]:rotate-180">
           {icon ?? <ChevronDown />}
@@ -43,7 +45,10 @@ const SelectBoxBase = ({
 
 const SelectBoxItem = ({ children, className, ...props }: SelectBoxItemProps) => {
   return (
-    <Shadcn.SelectItem className={cn("rounded-lg py-3 pl-3 text-base font-medium", className)} {...props}>
+    <Shadcn.SelectItem
+      className={cn("rounded-lg py-2 sm:py-2.5 pl-2 sm:pl-3 text-sm sm:text-base font-medium", className)}
+      {...props}
+    >
       {children}
     </Shadcn.SelectItem>
   );

--- a/packages/ui/src/components/ui/selectbox.tsx
+++ b/packages/ui/src/components/ui/selectbox.tsx
@@ -4,42 +4,43 @@ import { cn } from "@ui/lib/utils";
 import { ChevronDown } from "lucide-react";
 import type * as React from "react";
 
-interface SelectBoxProps extends React.ComponentProps<typeof Shadcn.Select> {
+type SelectBoxProps = React.ComponentProps<typeof Shadcn.Select>;
+
+interface SelectBoxTriggerProps extends React.ComponentProps<typeof Shadcn.SelectTrigger> {
   placeholder?: string;
   icon?: React.ReactNode;
-  triggerClassName?: string;
-  contentClassName?: string;
 }
-
 type SelectBoxItemProps = React.ComponentProps<typeof Shadcn.SelectItem>;
+type SelectBoxContentProps = React.ComponentProps<typeof Shadcn.SelectContent>;
 
-const SelectBoxBase = ({
-  placeholder,
-  children,
-  icon,
-  triggerClassName,
-  contentClassName,
-  ...props
-}: SelectBoxProps) => {
+const SelectBoxBase = ({ children, ...props }: SelectBoxProps) => {
+  return <Shadcn.Select {...props}>{children}</Shadcn.Select>;
+};
+
+const SelectBoxTrigger = ({ placeholder, icon, className, ...props }: SelectBoxTriggerProps) => {
   return (
-    <Shadcn.Select {...props}>
-      <Shadcn.SelectTrigger
-        className={cn("group py-2 min-h-11 sm:p-3 sm:min-h-12 text-base rounded-xl [&>svg]:hidden", triggerClassName)}
-      >
-        <Shadcn.SelectValue placeholder={placeholder} />
-        <span className="inline-flex items-center justify-center transition-transform group-data-[state=open]:rotate-180">
-          {icon ?? <ChevronDown />}
-        </span>
-      </Shadcn.SelectTrigger>
+    <Shadcn.SelectTrigger
+      className={cn("group min-h-11 py-2 text-base rounded-xl sm:min-h-12 sm:p-3 [&>svg]:hidden", className)}
+      {...props}
+    >
+      <Shadcn.SelectValue placeholder={placeholder} />
+      <span className="inline-flex items-center justify-center transition-transform group-data-[state=open]:rotate-180">
+        {icon ?? <ChevronDown />}
+      </span>
+    </Shadcn.SelectTrigger>
+  );
+};
 
-      <Shadcn.SelectContent
-        position="popper"
-        sideOffset={4}
-        className={cn("space-y-2 shadow-xl rounded-xl", contentClassName)}
-      >
-        <Shadcn.SelectGroup>{children}</Shadcn.SelectGroup>
-      </Shadcn.SelectContent>
-    </Shadcn.Select>
+const SelectBoxContent = ({ children, className, ...props }: SelectBoxContentProps) => {
+  return (
+    <Shadcn.SelectContent
+      position="popper"
+      sideOffset={4}
+      className={cn("space-y-2 rounded-xl shadow-xl", className)}
+      {...props}
+    >
+      <Shadcn.SelectGroup>{children}</Shadcn.SelectGroup>
+    </Shadcn.SelectContent>
   );
 };
 
@@ -55,5 +56,7 @@ const SelectBoxItem = ({ children, className, ...props }: SelectBoxItemProps) =>
 };
 
 export const SelectBox = Object.assign(SelectBoxBase, {
+  Trigger: SelectBoxTrigger,
+  Content: SelectBoxContent,
   Item: SelectBoxItem,
 });


### PR DESCRIPTION
## 📌 Summary

- Dropdown, SelectBox 래퍼 컴포넌트 추가 및 스토리북 작성
- close #4 

## 📄 Tasks

- shadcn `dropdown-menu`, `select` 컴포넌트 설치
- Dropdown, SelectBox 래퍼 컴포넌트 구현 
- 각 컴포넌트 스토리북 추가
- 코드리뷰 반영: 서브컴포넌트 노출 방식으로 수정

<br>

### Dropdown과 SelectBox를 분리한 기준
<img width="1873" height="1173" alt="Dropdown Reference" src="https://github.com/user-attachments/assets/40f0d803-9b5d-4d34-972a-1a121a9f17e8" />

  - **Dropdown**: 액션 메뉴를 위한 컴포넌트입니다. 항목 클릭 시 특정 동작이 실행되는 용도로 사용합니다.
  - **SelectBox**: 폼 입력을 위한 컴포넌트입니다. 사용자가 값을 선택하면 상태로 관리되고, 선택된 값이 트리거에 표시됩니다.
(추후, 스페이스 생성 시 테마 선택 UI 등에서 활용해도 좋을 것 같습니다.)
- [Dropdown Menu](https://ui.shadcn.com/docs/components/radix/dropdown-menu)
- [Select](https://ui.shadcn.com/docs/components/radix/select)

<br>

### 구현 시 고려한 점

**스타일링**
- 초기에는 width / height를 고정값으로 둘 예정이었지만, 추가된 기획에 따라 유동적으로 변경될 가능성을 고려했습니다. 
- 따라서 래퍼에서는 `min-w`, `min-h` 정도만 기본값으로 두고, 레이아웃 관련 값은 사용처에서 각 서브컴포넌트의 `className`으로 조절할 수 있도록 했습니다.

**SelectBox position 변경**
- shadcn Select의 기본 position은 `item-aligned`인데, 디자인에 맞게 `position="popper"`로 변경했습니다. 
- 이에 따라 ChevronDown 아이콘도 열림/닫힘 상태에서 rotate 되도록 추가했습니다.

**namespace import 패턴**
- shadcn 원본 컴포넌트는 `import * as Shadcn` 형태의 namespace import로 가져왔습니다.  
- 래퍼 내부에서 primitive와 커스텀 컴포넌트를 함께 사용하고,  
추후 커스텀이 추가될 가능성을 고려해 네임스페이스로 묶어 사용하는 방식이 가독성과 구분 측면에서 좋다고 판단했습니다.

**서브컴포넌트 노출 방식 (코드리뷰 반영)**
- 초기에는 `triggerClassName`, `contentClassName` prop으로 스타일을 확장하는 방식이었으나, 리뷰 의견을 반영하여 `Trigger`, `Content`를 서브컴포넌트로 노출하는 방식으로 변경했습니다.
- 각 요소에 직접 `className`을 줄 수 있어 더 직관적이고, 커스텀 prop 없이도 스타일 확장이 가능합니다.

<br>

### 예시
```tsx
   <SelectBox>
      <SelectBox.Trigger placeholder="지역을 선택하세요" />
      <SelectBox.Content>
        <SelectBox.Item value="all">지역 전체</SelectBox.Item>
        <SelectBox.Item value="konkuk">건대입구</SelectBox.Item>
        <SelectBox.Item value="euljiro">을지로 3가</SelectBox.Item>
        <SelectBox.Item value="sillim">신림</SelectBox.Item>
        <SelectBox.Item value="hongdae">홍대입구</SelectBox.Item>
      </SelectBox.Content>
    </SelectBox>
```

```tsx
    <Dropdown>
      <Dropdown.Trigger>
        <Button variant="ghost" type="button">
          <ListFilterIcon />
          마감임박
        </Button>
      </Dropdown.Trigger>
      <Dropdown.Content>
        <Dropdown.Item onSelect={() => console.log("마감임박")}>마감임박</Dropdown.Item>
        <Dropdown.Item onSelect={() => console.log("참여인원순")}>참여인원순</Dropdown.Item>
      </Dropdown.Content>
    </Dropdown>

   <Dropdown>
      <Dropdown.Trigger>
        <Button variant="ghost" size="icon-lg" type="button" aria-label="메뉴">
          <EllipsisIcon />
        </Button>
      </Dropdown.Trigger>
      <Dropdown.Content>
        <Dropdown.Item onSelect={() => console.log("수정")}>수정하기</Dropdown.Item>
        <Dropdown.Item onSelect={() => console.log("삭제")}>삭제하기</Dropdown.Item>
      </Dropdown.Content>
    </Dropdown>
```

## 👀 To Reviewer

- 래퍼 컴포넌트 구조와 스타일 확장 방식이 UI 패키지 구성 방향에 맞는지 의견 부탁드립니다.
  - className 기반 확장을 허용하는 방식으로 두었는데, 이 방향이 괜찮은지도 함께 봐주시면 좋을 것 같습니다.
- namespace import (import * as Shadcn) 사용 방식에 대해서도 의견 주시면 감사하겠습니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/dc610f3e-ea43-4bb7-8f09-31bd578db9c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 범용 드롭다운 메뉴 컴포넌트 추가(체크박스·라디오·서브메뉴·단축키·구분선 등 지원)
  * Radix 기반 셀렉트 컴포넌트 추가(크기·정렬·스크롤 버튼·아이템 인디케이터 등 지원)
  * 클라이언트용 Dropdown 및 SelectBox 합성 API로 간편 사용 가능

* **문서**
  * Storybook 예시 추가(드롭다운 및 셀렉트 사용 사례: 기본, 아이콘 전용, 모든 케이스)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->