### PR TITLE
[style] 글로벌 스타일 설정 추가

### DIFF
--- a/packages/ui/src/components/stories/underline-tab-button.stories.tsx
+++ b/packages/ui/src/components/stories/underline-tab-button.stories.tsx
@@ -57,27 +57,25 @@ export const Large: Story = {
 export const AllCases: Story = {
   render: () => {
     return (
-      <>
-        <div className="flex flex-col gap-8 p-8">
-          <div className="flex items-end gap-8">
-            <UnderlineTabButton variant="default" size="large">
-              나의 모임
-            </UnderlineTabButton>
-            <UnderlineTabButton variant="default" size="small">
-              나의 모임
-            </UnderlineTabButton>
-          </div>
-
-          <div className="flex items-end gap-8">
-            <UnderlineTabButton variant="active" size="large">
-              나의 모임
-            </UnderlineTabButton>
-            <UnderlineTabButton variant="active" size="small">
-              나의 모임
-            </UnderlineTabButton>
-          </div>
+      <div className="flex flex-col gap-8 p-8">
+        <div className="flex items-end gap-8">
+          <UnderlineTabButton variant="default" size="large">
+            나의 모임
+          </UnderlineTabButton>
+          <UnderlineTabButton variant="default" size="small">
+            나의 모임
+          </UnderlineTabButton>
         </div>
-      </>
+
+        <div className="flex items-end gap-8">
+          <UnderlineTabButton variant="active" size="large">
+            나의 모임
+          </UnderlineTabButton>
+          <UnderlineTabButton variant="active" size="small">
+            나의 모임
+          </UnderlineTabButton>
+        </div>
+      </div>
     );
   },
 };

--- a/packages/ui/src/global.css
+++ b/packages/ui/src/global.css
@@ -5,6 +5,7 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+  /* color tokens */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -24,11 +25,15 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+
+  /* chart color tokens */
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
+
+  /* radius tokens */
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
@@ -36,6 +41,8 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+
+  /* sidebar color tokens */
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);
@@ -48,29 +55,40 @@
 
 :root {
   --radius: 0.625rem;
+
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
+
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
+
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
+
   --primary: #00bd7e;
   --primary-foreground: #ffffff;
+
   --secondary: #2196f3;
   --secondary-foreground: #ffffff;
+
   --muted: #edefef;
   --muted-foreground: #737373;
+
   --accent: #edfff5;
   --accent-foreground: #00bd7e;
+
   --destructive: oklch(0.577 0.245 27.325);
+
   --border: #d9d9d9;
   --input: #d9d9d9;
   --ring: #00bd7e;
+
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
+
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -86,27 +104,37 @@
 .dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
+
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
+
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
+
   --primary: #00bd7e;
   --primary-foreground: #ffffff;
+
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
+
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
+
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
+
   --destructive: oklch(0.704 0.191 22.216);
+
   --border: #333333;
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
+
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
+
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
@@ -123,8 +151,77 @@
   * {
     @apply border-border outline-ring/50;
   }
+
+  html {
+    scroll-behavior: smooth;
+
+    /* 브라우저 폰트 크기 자동 조정 방지 */
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
   body {
     @apply bg-background text-foreground;
+
+    /* 텍스트 가독성과 폰트 렌더링 보정 */
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  html,
+  body {
+    /* layout height 기준 설정 */
+    height: 100%;
+  }
+
+  a {
+    /* 링크 기본 스타일 제거 */
+    color: inherit;
+    text-decoration: none;
+  }
+
+  input,
+  button,
+  textarea,
+  select {
+    /* 폼 요소가 전역 폰트/색상을 상속받도록 설정 */
+    font: inherit;
+    color: inherit;
+  }
+
+  button {
+    cursor: pointer;
+    /* 버튼 기본 스타일 reset */
+    border: none;
+    padding: 0;
+    background: none;
+  }
+
+  :disabled {
+    /* 비활성 요소 커서 */
+    cursor: not-allowed;
+  }
+
+  textarea {
+    /* 레이아웃 깨짐 방지 */
+    resize: vertical;
+  }
+
+  img,
+  video {
+    /* 이미지/미디어 기본 설정 */
+    max-width: 100%;
+    height: auto;
+  }
+
+  img,
+  svg,
+  video,
+  button {
+    /* 드래그/텍스트 선택 방지 */
+    -webkit-user-drag: none;
+    user-select: none;
   }
 }
 
@@ -133,9 +230,32 @@
 }
 
 @utility no-scrollbar {
+  /* 스크롤바 숨김 */
   -ms-overflow-style: none;
   scrollbar-width: none;
+
   &::-webkit-scrollbar {
     display: none;
   }
+}
+
+@utility container-desktop {
+  /* 공통 데스크톱 콘텐츠 너비 */
+  width: 100%;
+  max-width: 1200px;
+  margin-inline: auto;
+  padding-inline: 24px;
+}
+
+@utility sr-only {
+  /* 스크린리더 전용 텍스트 */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }


### PR DESCRIPTION
## 📌 Summary

글로벌 스타일 및 공통 utility 스타일을 추가했습니다.

- close #19 

## 📄 Tasks
- 글로벌 base 스타일 설정
  - 링크 기본 스타일 제거
  - 폼 요소 폰트/컬러 상속 설정
  - 버튼 기본 스타일 reset 및 cursor 설정
  - disabled 요소 cursor 스타일 추가
  - textarea 리사이즈 방향 제한
  - 이미지/미디어 기본 스타일 설정
  - 드래그 및 텍스트 선택 방지 설정
- 공통 utility 스타일 추가
  - `container-desktop`
  - `sr-only`

## 👀 To Reviewer
- 최소한의 reset과 공통 스타일 위주로 추가해 우선은 파일을 따로 분리하지 않았습니다.
- 추가하거나 제거하면 좋을 설정 있으시면 말씀해 주세요!

## 📸 Screenshot
