### PR TITLE
[fix] 인증구조 변경 기반 마이그레이션 및 비로그인 버튼 UX 수정

### DIFF
--- a/apps/web/src/_pages/space-search/actions.ts
+++ b/apps/web/src/_pages/space-search/actions.ts
@@ -1,26 +1,57 @@
 "use server";
 
-import { redirect } from "next/navigation";
-import { getApi } from "@/shared/api/server";
-import { ROUTES } from "@/shared/config/routes";
+import { getApi, isAuth } from "@/shared/api/server";
+
 import { createSearchFavorite } from "./use-cases/create-search-favorite";
 import { deleteSearchFavorite } from "./use-cases/delete-search-favorite";
 
-export const createSearchFavoriteAction = async (meetingId: number) => {
-  const api = await getApi();
+type FavoriteActionResult =
+  | {
+      error: "UNAUTHORIZED";
+      ok: false;
+    }
+  | {
+      data: {
+        isLiked: boolean;
+        meetingId: number;
+      };
+      ok: true;
+    };
 
-  return createSearchFavorite({ meetingId }, { favoritesApi: api.favorites });
+export const createSearchFavoriteAction = async (meetingId: number): Promise<FavoriteActionResult> => {
+  const { authenticated } = await isAuth();
+
+  if (!authenticated) {
+    return {
+      error: "UNAUTHORIZED",
+      ok: false,
+    };
+  }
+
+  const api = await getApi();
+  const result = await createSearchFavorite({ meetingId }, { favoritesApi: api.favorites });
+
+  return {
+    data: result,
+    ok: true,
+  };
 };
 
-export const deleteSearchFavoriteAction = async (meetingId: number) => {
+export const deleteSearchFavoriteAction = async (meetingId: number): Promise<FavoriteActionResult> => {
+  const { authenticated } = await isAuth();
+
+  if (!authenticated) {
+    return {
+      error: "UNAUTHORIZED",
+      ok: false,
+    };
+  }
+
   const api = await getApi();
+  const result = await deleteSearchFavorite({ meetingId }, { favoritesApi: api.favorites });
 
-  return deleteSearchFavorite({ meetingId }, { favoritesApi: api.favorites });
-};
-
-export const redirectToMoimCreateAction = async () => {
-  const api = await getApi();
-
-  void api; // TODO: 대체 방법 고민 // 인증 확인용 — 미인증 시 onAuthFailed에서 redirect
-  redirect(ROUTES.moimCreate);
+  return {
+    data: result,
+    ok: true,
+  };
 };

--- a/apps/web/src/_pages/space-search/lib/get-search-meetings-api.ts
+++ b/apps/web/src/_pages/space-search/lib/get-search-meetings-api.ts
@@ -1,20 +1,22 @@
 import "server-only";
 
 import { api } from "@/shared/api";
-import { getApi } from "@/shared/api/server";
+import { getApi, isAuth } from "@/shared/api/server";
 
 export const getSearchMeetingsApi = async () => {
-  try {
-    const api = await getApi();
+  const { authenticated } = await isAuth();
 
-    return {
-      isAuthenticatedRequest: true,
-      meetingsApi: api.meetings,
-    };
-  } catch {
+  if (!authenticated) {
     return {
       isAuthenticatedRequest: false,
       meetingsApi: api.meetings,
     };
   }
+
+  const client = await getApi();
+
+  return {
+    isAuthenticatedRequest: true,
+    meetingsApi: client.meetings,
+  };
 };

--- a/apps/web/src/_pages/space-search/use-cases/create-search-favorite.ts
+++ b/apps/web/src/_pages/space-search/use-cases/create-search-favorite.ts
@@ -12,7 +12,11 @@ export const createSearchFavorite = async (
   { meetingId }: CreateSearchFavoriteInput,
   { favoritesApi }: CreateSearchFavoriteDeps,
 ) => {
-  await favoritesApi.create(meetingId);
+  const timerLabel = `[search] POST /favorites meetingId=${meetingId}`;
+  console.time(timerLabel);
+  await favoritesApi.create(meetingId).finally(() => {
+    console.timeEnd(timerLabel);
+  });
 
   return {
     meetingId,

--- a/apps/web/src/_pages/space-search/use-cases/create-search-favorite.ts
+++ b/apps/web/src/_pages/space-search/use-cases/create-search-favorite.ts
@@ -12,7 +12,7 @@ export const createSearchFavorite = async (
   { meetingId }: CreateSearchFavoriteInput,
   { favoritesApi }: CreateSearchFavoriteDeps,
 ) => {
-  const timerLabel = `[search] POST /favorites meetingId=${meetingId}`;
+  const timerLabel = `[search] POST /favorites meetingId=${meetingId} requestId=${Date.now()}-${Math.random().toString(36).slice(2)}`;
   console.time(timerLabel);
   await favoritesApi.create(meetingId).finally(() => {
     console.timeEnd(timerLabel);

--- a/apps/web/src/_pages/space-search/use-cases/delete-search-favorite.ts
+++ b/apps/web/src/_pages/space-search/use-cases/delete-search-favorite.ts
@@ -12,7 +12,7 @@ export const deleteSearchFavorite = async (
   { meetingId }: DeleteSearchFavoriteInput,
   { favoritesApi }: DeleteSearchFavoriteDeps,
 ) => {
-  const timerLabel = `[search] DELETE /favorites meetingId=${meetingId}`;
+  const timerLabel = `[search] DELETE /favorites meetingId=${meetingId} requestId=${Date.now()}-${Math.random().toString(36).slice(2)}`;
   console.time(timerLabel);
   await favoritesApi.delete(meetingId).finally(() => {
     console.timeEnd(timerLabel);

--- a/apps/web/src/_pages/space-search/use-cases/delete-search-favorite.ts
+++ b/apps/web/src/_pages/space-search/use-cases/delete-search-favorite.ts
@@ -12,7 +12,11 @@ export const deleteSearchFavorite = async (
   { meetingId }: DeleteSearchFavoriteInput,
   { favoritesApi }: DeleteSearchFavoriteDeps,
 ) => {
-  await favoritesApi.delete(meetingId);
+  const timerLabel = `[search] DELETE /favorites meetingId=${meetingId}`;
+  console.time(timerLabel);
+  await favoritesApi.delete(meetingId).finally(() => {
+    console.timeEnd(timerLabel);
+  });
 
   return {
     meetingId,

--- a/apps/web/src/_pages/space-search/use-cases/get-search-categories.ts
+++ b/apps/web/src/_pages/space-search/use-cases/get-search-categories.ts
@@ -14,6 +14,9 @@ interface GetSearchCategoriesDeps {
 export const getSearchCategories = async ({
   meetingTypesApi = api.meetingTypes,
 }: GetSearchCategoriesDeps = {}): Promise<SpaceSearchCategory[]> => {
+  const timerLabel = "[search] GET /meeting-types";
+  console.time(timerLabel);
+
   try {
     const response = await meetingTypesApi.getList();
     const meetingTypes = response.data as MeetingTypesListData;
@@ -35,7 +38,9 @@ export const getSearchCategories = async ({
 
     return [DEFAULT_SEARCH_CATEGORY, ...categories];
   } catch (error) {
-    //TODO: 에러처리
+    console.error("[search] failed to get categories", { error });
     return [DEFAULT_SEARCH_CATEGORY];
+  } finally {
+    console.timeEnd(timerLabel);
   }
 };

--- a/apps/web/src/_pages/space-search/use-cases/get-search-categories.ts
+++ b/apps/web/src/_pages/space-search/use-cases/get-search-categories.ts
@@ -14,8 +14,7 @@ interface GetSearchCategoriesDeps {
 export const getSearchCategories = async ({
   meetingTypesApi = api.meetingTypes,
 }: GetSearchCategoriesDeps = {}): Promise<SpaceSearchCategory[]> => {
-  const timerLabel = "[search] GET /meeting-types";
-  console.time(timerLabel);
+  const startedAt = Date.now();
 
   try {
     const response = await meetingTypesApi.getList();
@@ -41,6 +40,6 @@ export const getSearchCategories = async ({
     console.error("[search] failed to get categories", { error });
     return [DEFAULT_SEARCH_CATEGORY];
   } finally {
-    console.timeEnd(timerLabel);
+    console.info("[search] GET /meeting-types", { durationMs: Date.now() - startedAt });
   }
 };

--- a/apps/web/src/_pages/space-search/use-cases/get-search-results.ts
+++ b/apps/web/src/_pages/space-search/use-cases/get-search-results.ts
@@ -131,17 +131,23 @@ export const getSearchResults = async (
   { isAuthenticatedRequest = false, meetingsApi = api.meetings }: GetSearchResultsDeps = {},
 ): Promise<SearchResultsResponse> => {
   const { sortBy, sortOrder } = resolveSortParams({ dateSortId, deadlineSortId });
-  const response = await meetingsApi.getList(
-    {
-      cursor: cursor ?? undefined,
-      region: locationId === "all" ? undefined : locationId,
-      size,
-      sortBy,
-      sortOrder,
-      type: categoryId === "all" ? undefined : getGatheringCategoryRequestType(categoryId),
-    },
-    { cache: "no-store" },
-  );
+  const timerLabel = `[search] GET /meetings category=${categoryId} location=${locationId} cursor=${cursor ?? "none"} size=${size}`;
+  console.time(timerLabel);
+  const response = await meetingsApi
+    .getList(
+      {
+        cursor: cursor ?? undefined,
+        region: locationId === "all" ? undefined : locationId,
+        size,
+        sortBy,
+        sortOrder,
+        type: categoryId === "all" ? undefined : getGatheringCategoryRequestType(categoryId),
+      },
+      { cache: "no-store" },
+    )
+    .finally(() => {
+      console.timeEnd(timerLabel);
+    });
   const searchResults = response.data as MeetingsListData;
   const meetings = searchResults.data as SearchMeetingWithUserState[];
   warnMissingFavoritedField(meetings, isAuthenticatedRequest);

--- a/apps/web/src/app/(main)/search/page.tsx
+++ b/apps/web/src/app/(main)/search/page.tsx
@@ -25,9 +25,7 @@ export default async function SpacePage({ searchParams }: SpacePageProps) {
   const resolvedSearchParams = await searchParams;
   const queryState = parseSpaceSearchQueryState(resolvedSearchParams);
   const normalizedQueryState = normalizeSearchQueryState(queryState);
-
   const { isAuthenticatedRequest, meetingsApi } = await getSearchMeetingsApi();
-
   const queryClient = getQueryClient();
   const initialPageParam: string | null = null;
 
@@ -68,8 +66,15 @@ export default async function SpacePage({ searchParams }: SpacePageProps) {
       </main>
 
       <div className="fixed right-4 bottom-6 z-20 sm:right-6 sm:bottom-8 xl:right-0 2xl:right-6">
-        <SpaceSearchCreateButton aria-label="스페이스 만들기" className="sm:hidden" variant="icon" />
-        <SpaceSearchCreateButton className="hidden sm:inline-flex">스페이스 만들기</SpaceSearchCreateButton>
+        <SpaceSearchCreateButton
+          aria-label="스페이스 만들기"
+          className="sm:hidden"
+          isAuthenticated={isAuthenticatedRequest}
+          variant="icon"
+        />
+        <SpaceSearchCreateButton className="hidden sm:inline-flex" isAuthenticated={isAuthenticatedRequest}>
+          스페이스 만들기
+        </SpaceSearchCreateButton>
       </div>
     </div>
   );

--- a/apps/web/src/features/space-search/apis/get-search-results.ts
+++ b/apps/web/src/features/space-search/apis/get-search-results.ts
@@ -42,7 +42,12 @@ export const getSearchResults = async ({
   }
 
   const queryString = searchParams.toString();
-  const response = await fetch(queryString ? `/api/search?${queryString}` : "/api/search");
+  const requestUrl = queryString ? `/api/search?${queryString}` : "/api/search";
+  const timerLabel = `[search] GET ${requestUrl}`;
+  console.time(timerLabel);
+  const response = await fetch(requestUrl).finally(() => {
+    console.timeEnd(timerLabel);
+  });
 
   if (!response.ok) {
     const errorBody = await response.text();

--- a/apps/web/src/features/space-search/ui/space-card-join-button.tsx
+++ b/apps/web/src/features/space-search/ui/space-card-join-button.tsx
@@ -1,21 +1,25 @@
 "use client";
 
-import { Button } from "@ui/components";
+import { Button, toast } from "@ui/components";
 import { useRouter } from "next/navigation";
 import type { ComponentProps } from "react";
 
 import { ROUTES } from "@/shared/config/routes";
 
-type SpaceCardJoinButtonProps = ComponentProps<typeof Button> & { meetingId: string };
+interface SpaceCardJoinButtonProps extends Omit<ComponentProps<typeof Button>, "onClick"> {
+  isAuthenticated: boolean;
+  meetingId: string;
+}
 
-export const SpaceCardJoinButton = ({ onClick, meetingId, ...props }: SpaceCardJoinButtonProps) => {
+export const SpaceCardJoinButton = ({ isAuthenticated, meetingId, ...props }: SpaceCardJoinButtonProps) => {
   const router = useRouter();
 
-  // TODO: 라우팅 용 버튼인데 onClick compose할 필요 없어 보임
-  const handleClick: SpaceCardJoinButtonProps["onClick"] = (event) => {
-    onClick?.(event);
-
-    if (event.defaultPrevented) {
+  const handleClick = () => {
+    if (!isAuthenticated) {
+      toast({
+        message: "로그인 후 이용할 수 있어요.",
+        size: "small",
+      });
       return;
     }
 

--- a/apps/web/src/features/space-search/ui/space-card-like-button.tsx
+++ b/apps/web/src/features/space-search/ui/space-card-like-button.tsx
@@ -86,6 +86,12 @@ export const SpaceCardLikeButton = ({ isAuthenticated, isLiked = false, meetingI
   const [optimisticIsLiked, setOptimisticIsLiked] = useState(isLiked);
   const [isPending, startTransition] = useTransition();
   const queryClient = useQueryClient();
+  const matchesSearchResultsQuery = (queryKey: readonly unknown[]) =>
+    queryKey[0] === spaceSearchQueryKeys.all[0] &&
+    typeof queryKey[2] === "object" &&
+    queryKey[2] !== null &&
+    "isAuthenticated" in queryKey[2] &&
+    queryKey[2].isAuthenticated === isAuthenticated;
 
   useEffect(() => {
     setOptimisticIsLiked(isLiked);
@@ -112,7 +118,7 @@ export const SpaceCardLikeButton = ({ isAuthenticated, isLiked = false, meetingI
       setOptimisticIsLiked(previousIsLiked);
       queryClient.setQueriesData<SearchResultsInfiniteData>(
         {
-          predicate: (query) => query.queryKey[0] === spaceSearchQueryKeys.all[0],
+          predicate: (query) => matchesSearchResultsQuery(query.queryKey),
         },
         (cachedData) => updateLikedStateInSearchResults(cachedData, meetingId, previousIsLiked),
       );
@@ -121,14 +127,15 @@ export const SpaceCardLikeButton = ({ isAuthenticated, isLiked = false, meetingI
     setOptimisticIsLiked(nextIsLiked);
     queryClient.setQueriesData<SearchResultsInfiniteData>(
       {
-        predicate: (query) => query.queryKey[0] === spaceSearchQueryKeys.all[0],
+        predicate: (query) => matchesSearchResultsQuery(query.queryKey),
       },
       (cachedData) => updateLikedStateInSearchResults(cachedData, meetingId, nextIsLiked),
     );
 
+    const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
     const timerLabel = nextIsLiked
-      ? `[search] client like action meetingId=${meetingId}`
-      : `[search] client unlike action meetingId=${meetingId}`;
+      ? `[search] client like action meetingId=${meetingId} requestId=${requestId}`
+      : `[search] client unlike action meetingId=${meetingId} requestId=${requestId}`;
     console.time(timerLabel);
 
     startTransition(async () => {
@@ -139,8 +146,17 @@ export const SpaceCardLikeButton = ({ isAuthenticated, isLiked = false, meetingI
 
         if (!result.ok) {
           rollbackLikedState();
+
+          if (result.error === "UNAUTHORIZED") {
+            toast({
+              message: "로그인 후 이용할 수 있어요.",
+              size: "small",
+            });
+            return;
+          }
+
           toast({
-            message: "로그인 후 이용할 수 있어요.",
+            message: "요청에 실패했어요. 다시 시도해 주세요.",
             size: "small",
           });
         }
@@ -148,12 +164,13 @@ export const SpaceCardLikeButton = ({ isAuthenticated, isLiked = false, meetingI
         rollbackLikedState();
 
         if (isRedirectError(error)) {
-          toast({
-            message: "로그인 후 이용할 수 있어요.",
-            size: "small",
-          });
-          return;
+          throw error;
         }
+
+        toast({
+          message: "요청에 실패했어요. 다시 시도해 주세요.",
+          size: "small",
+        });
       } finally {
         console.timeEnd(timerLabel);
       }

--- a/apps/web/src/features/space-search/ui/space-card-like-button.tsx
+++ b/apps/web/src/features/space-search/ui/space-card-like-button.tsx
@@ -86,12 +86,19 @@ export const SpaceCardLikeButton = ({ isAuthenticated, isLiked = false, meetingI
   const [optimisticIsLiked, setOptimisticIsLiked] = useState(isLiked);
   const [isPending, startTransition] = useTransition();
   const queryClient = useQueryClient();
-  const matchesSearchResultsQuery = (queryKey: readonly unknown[]) =>
-    queryKey[0] === spaceSearchQueryKeys.all[0] &&
-    typeof queryKey[2] === "object" &&
-    queryKey[2] !== null &&
-    "isAuthenticated" in queryKey[2] &&
-    queryKey[2].isAuthenticated === isAuthenticated;
+  const matchesSearchResultsQuery = (queryKey: readonly unknown[]) => {
+    const authSegment = queryKey[2];
+
+    if (queryKey[0] !== spaceSearchQueryKeys.all[0]) {
+      return false;
+    }
+
+    if (!authSegment || typeof authSegment !== "object") {
+      return false;
+    }
+
+    return "isAuthenticated" in authSegment && authSegment.isAuthenticated === isAuthenticated;
+  };
 
   useEffect(() => {
     setOptimisticIsLiked(isLiked);

--- a/apps/web/src/features/space-search/ui/space-card-like-button.tsx
+++ b/apps/web/src/features/space-search/ui/space-card-like-button.tsx
@@ -2,7 +2,7 @@
 
 import type { InfiniteData } from "@tanstack/react-query";
 import { useQueryClient } from "@tanstack/react-query";
-import { UtilityButton } from "@ui/components";
+import { toast, UtilityButton } from "@ui/components";
 import { useEffect, useState, useTransition } from "react";
 
 import { createSearchFavoriteAction, deleteSearchFavoriteAction } from "@/_pages/space-search/actions";
@@ -12,6 +12,7 @@ import HeartIcon from "../assets/heart-default.svg";
 import { spaceSearchQueryKeys } from "../model/query-keys";
 
 interface SpaceCardLikeButtonProps {
+  isAuthenticated: boolean;
   isLiked?: boolean;
   meetingId: string;
 }
@@ -81,7 +82,7 @@ const updateLikedStateInSearchResults = (
   };
 };
 
-export const SpaceCardLikeButton = ({ isLiked = false, meetingId }: SpaceCardLikeButtonProps) => {
+export const SpaceCardLikeButton = ({ isAuthenticated, isLiked = false, meetingId }: SpaceCardLikeButtonProps) => {
   const [optimisticIsLiked, setOptimisticIsLiked] = useState(isLiked);
   const [isPending, startTransition] = useTransition();
   const queryClient = useQueryClient();
@@ -91,6 +92,14 @@ export const SpaceCardLikeButton = ({ isLiked = false, meetingId }: SpaceCardLik
   }, [isLiked]);
 
   const handleClick = () => {
+    if (!isAuthenticated) {
+      toast({
+        message: "로그인 후 이용할 수 있어요.",
+        size: "small",
+      });
+      return;
+    }
+
     const parsedMeetingId = Number(meetingId);
 
     if (!Number.isFinite(parsedMeetingId)) {
@@ -119,19 +128,27 @@ export const SpaceCardLikeButton = ({ isLiked = false, meetingId }: SpaceCardLik
 
     startTransition(async () => {
       try {
-        if (nextIsLiked) {
-          await createSearchFavoriteAction(parsedMeetingId);
-        } else {
-          await deleteSearchFavoriteAction(parsedMeetingId);
+        const result = nextIsLiked
+          ? await createSearchFavoriteAction(parsedMeetingId)
+          : await deleteSearchFavoriteAction(parsedMeetingId);
+
+        if (!result.ok) {
+          rollbackLikedState();
+          toast({
+            message: "로그인 후 이용할 수 있어요.",
+            size: "small",
+          });
         }
       } catch (error) {
-        if (isRedirectError(error)) {
-          rollbackLikedState();
-
-          throw error;
-        }
-
         rollbackLikedState();
+
+        if (isRedirectError(error)) {
+          toast({
+            message: "로그인 후 이용할 수 있어요.",
+            size: "small",
+          });
+          return;
+        }
       }
     });
   };

--- a/apps/web/src/features/space-search/ui/space-card-like-button.tsx
+++ b/apps/web/src/features/space-search/ui/space-card-like-button.tsx
@@ -126,6 +126,11 @@ export const SpaceCardLikeButton = ({ isAuthenticated, isLiked = false, meetingI
       (cachedData) => updateLikedStateInSearchResults(cachedData, meetingId, nextIsLiked),
     );
 
+    const timerLabel = nextIsLiked
+      ? `[search] client like action meetingId=${meetingId}`
+      : `[search] client unlike action meetingId=${meetingId}`;
+    console.time(timerLabel);
+
     startTransition(async () => {
       try {
         const result = nextIsLiked
@@ -149,6 +154,8 @@ export const SpaceCardLikeButton = ({ isAuthenticated, isLiked = false, meetingI
           });
           return;
         }
+      } finally {
+        console.timeEnd(timerLabel);
       }
     });
   };

--- a/apps/web/src/features/space-search/ui/space-card.tsx
+++ b/apps/web/src/features/space-search/ui/space-card.tsx
@@ -7,6 +7,7 @@ import { SpaceCardJoinButton } from "./space-card-join-button";
 import { SpaceCardLikeButton } from "./space-card-like-button";
 
 interface SpaceCardProps {
+  isAuthenticated: boolean;
   item: SpaceCardItem;
 }
 
@@ -31,7 +32,7 @@ const SpaceCardStatus = ({ label }: { label: string }) => {
   );
 };
 
-export const SpaceCard = ({ item }: SpaceCardProps) => {
+export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
   const {
     category,
     currentParticipants,
@@ -59,7 +60,7 @@ export const SpaceCard = ({ item }: SpaceCardProps) => {
           width={340}
         />
         <div className="absolute top-4 right-4 sm:hidden">
-          <SpaceCardLikeButton isLiked={isLiked} meetingId={item.id} />
+          <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={item.id} />
         </div>
       </div>
 
@@ -81,7 +82,7 @@ export const SpaceCard = ({ item }: SpaceCardProps) => {
           </div>
 
           <div className="hidden sm:block">
-            <SpaceCardLikeButton isLiked={isLiked} meetingId={item.id} />
+            <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={item.id} />
           </div>
         </div>
 
@@ -112,6 +113,7 @@ export const SpaceCard = ({ item }: SpaceCardProps) => {
             )}
             size="small"
             variant="secondary"
+            isAuthenticated={isAuthenticated}
             meetingId={meetingId}
           >
             참여하기

--- a/apps/web/src/features/space-search/ui/space-search-create-button.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-create-button.tsx
@@ -1,15 +1,22 @@
 "use client";
 
-import { CreateButton } from "@ui/components";
+import { CreateButton, toast } from "@ui/components";
+import { useRouter } from "next/navigation";
 import type { ComponentProps } from "react";
-import { useTransition } from "react";
 
-import { redirectToMoimCreateAction } from "@/_pages/space-search/actions";
+import { ROUTES } from "@/shared/config/routes";
 
-type SpaceSearchCreateButtonProps = ComponentProps<typeof CreateButton>;
+interface SpaceSearchCreateButtonProps extends ComponentProps<typeof CreateButton> {
+  isAuthenticated: boolean;
+}
 
-export const SpaceSearchCreateButton = ({ disabled, onClick, ...props }: SpaceSearchCreateButtonProps) => {
-  const [isPending, startTransition] = useTransition();
+export const SpaceSearchCreateButton = ({
+  disabled,
+  isAuthenticated,
+  onClick,
+  ...props
+}: SpaceSearchCreateButtonProps) => {
+  const router = useRouter();
 
   const handleClick: SpaceSearchCreateButtonProps["onClick"] = (event) => {
     onClick?.(event);
@@ -18,10 +25,16 @@ export const SpaceSearchCreateButton = ({ disabled, onClick, ...props }: SpaceSe
       return;
     }
 
-    startTransition(async () => {
-      await redirectToMoimCreateAction();
-    });
+    if (!isAuthenticated) {
+      toast({
+        message: "로그인 후 이용할 수 있어요.",
+        size: "small",
+      });
+      return;
+    }
+
+    router.push(ROUTES.moimCreate);
   };
 
-  return <CreateButton {...props} disabled={disabled || isPending} onClick={handleClick} />;
+  return <CreateButton {...props} disabled={disabled} onClick={handleClick} />;
 };

--- a/apps/web/src/features/space-search/ui/space-search-results.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-results.tsx
@@ -7,11 +7,18 @@ import { SpaceCard } from "./space-card";
 interface SpaceSearchResultsProps {
   errorMessage?: string;
   hasMore: boolean;
+  isAuthenticated: boolean;
   items: SpaceCardItem[];
   loadMoreRef: RefObject<HTMLDivElement | null>;
 }
 
-export const SpaceSearchResults = ({ errorMessage, hasMore, items, loadMoreRef }: SpaceSearchResultsProps) => {
+export const SpaceSearchResults = ({
+  errorMessage,
+  hasMore,
+  isAuthenticated,
+  items,
+  loadMoreRef,
+}: SpaceSearchResultsProps) => {
   if (items.length === 0) {
     return (
       <section className="rounded-[2rem] px-6 py-16">
@@ -26,7 +33,7 @@ export const SpaceSearchResults = ({ errorMessage, hasMore, items, loadMoreRef }
     <section className="flex flex-col gap-8">
       <div className="grid gap-6 xl:grid-cols-2">
         {items.map((item) => (
-          <SpaceCard item={item} key={item.id} />
+          <SpaceCard isAuthenticated={isAuthenticated} item={item} key={item.id} />
         ))}
       </div>
       {errorMessage ? (

--- a/apps/web/src/features/space-search/ui/space-search-sections.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-sections.tsx
@@ -204,6 +204,7 @@ const InfiniteSpaceSearchResults = ({ isAuthenticated, queryState }: SpaceSearch
     <SpaceSearchResults
       errorMessage={errorMessage}
       hasMore={Boolean(hasNextPage && !hasQueryError)}
+      isAuthenticated={isAuthenticated}
       items={items}
       loadMoreRef={loadMoreRef}
     />


### PR DESCRIPTION
## 📌 Summary

/search 페이지를 변경된 인증 API 구조(isAuth, getApi)에 맞게 마이그레이션했습니다.

인증 여부 판단 방식이 바뀌면서 깨졌던 비로그인 유저 라우팅분기, 좋아요 액션, 버튼 동작을 수정했습니다.
또한 비로그인 사용자의 하트/참여하기/스페이스 만들기 버튼 동작을 리다이렉트가 아닌 토스트 안내 방식으로 정리했습니다.
- close #78 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- 인증 함수 마이그레이션

auth-client.ts 제거 이후 /search에서 사용하던 인증 흐름을 isAuth() + getApi() 기준으로 수정했습니다.
`isAuth()`로 먼저 인증 여부를 판단하도록 정리했습니다.

- 검색 목록 API 분기 수정

비로그인 사용자는 public api.meetings, 로그인 사용자는 getApi().meetings를 사용하도록 분기했습니다.
인증 여부는 `getSearchMeetingsApi()`에서 계산하고, 최상위 페이지에서 내려주도록 정리했습니다.

- 좋아요 액션 수정

좋아요/좋아요 해제 server action에서 isAuth()로 서버 2차 방어를 추가했습니다.
비로그인 상태에서는 redirect 대신 { ok: false, error: "UNAUTHORIZED" }를 반환하도록 변경했습니다.

**좋아요 버튼은 비로그인 사용자의 클릭 시 API 요청을 보내지 않고 토스트만 표시하도록 수정했습니다.**

- 버튼 UX 수정

참여하기 버튼은 비로그인 시 토스트를 표시하고, 로그인 시에만 상세 페이지로 이동하도록 수정했습니다.
스페이스 만들기 버튼은 비로그인 시 토스트를 표시하고, 로그인 시에만 /moim-create로 이동하도록 수정했습니다.

- 인증 상태 전달 구조 정리

최상위 /search page에서 계산한 인증 여부를 검색 결과 섹션과 버튼들로 prop으로 내려주도록 정리했습니다.
검색 query key도 인증 상태를 포함하도록 유지하여 로그인/비로그인 캐시가 섞이지 않게 했습니다.

- 디버깅 보강

/search에서 사용하는 주요 API 요청에 console.time()/console.timeEnd()를 추가해 성능 디버깅이 가능하도록 했습니다.
- GET /meetings
- GET /meeting-types
- POST /favorites
- DELETE /favorites
- 클라이언트 GET /api/search

/favorites(좋아요) 요청은 Server Action 구조상 브라우저 네트워크 탭 /search 액션 요청으로 보이므로, 
클라이언트 체감 시간을 별도 콘솔타이머로 확인할 수 있게 했습니다.
## 👀 To Reviewer

- 비로그인 사용자의 하트/참여하기/스페이스 만들기 버튼은 이제 /login으로 redirect가 아닌 토스트 UX를 사용합니다.
- 좋아요는 여전히 server action을 통해 처리되며, 서버에서 한 번 더 isAuth()로 방어합니다.
- 코드 가독성 및 prop drililng 현상 개선이 추후, 중간발표 이후나 고도화 시기에 필요해 보입니다.  


## 📸 Screenshot

```
- 기존
  A["좋아요/스페이스 만들기 클릭"] --> B["Server Action"]
  B --> C{"isAuthenticated()"}
  C -- "false" --> D["redirect /login"]
  C -- "true" --> E["getAuthenticatedApi()"]
  E --> F["API 호출"]

```
<img width="1199" height="254" alt="image" src="https://github.com/user-attachments/assets/41fba825-10bd-4aa1-bbfd-de49194aee37" />

 ```
- 현재
  A["/search 서버 렌더"] --> B["isAuth()"]
  B --> C["isAuthenticated prop 전달"]

  C --> D["하트/참여하기/스페이스 만들기 클릭"]
  D --> E{"isAuthenticated?"}
  E -- "false" --> F["토스트 표시 후 종료"]
  E -- "true" --> G["좋아요: Server Action / 나머지: router.push"]

```
<img width="1549" height="251" alt="image" src="https://github.com/user-attachments/assets/13076887-c92c-41b3-ad77-c5579a5ec5d7" />


 ```
- 좋아요만 2차 검증
  A["좋아요 클릭"] --> B{"client isAuthenticated?"}
  B -- "false" --> C["토스트 + API 안 보냄"]
  B -- "true" --> D["낙관적 UI 적용"]
  D --> E["create/deleteSearchFavoriteAction"]
  E --> F{"server isAuth()"}
  F -- "false" --> G["{ ok: false, error: UNAUTHORIZED }"]
  F -- "true" --> H["getApi().favorites 호출"]
  G --> I["카드만 롤백 + 토스트"]
  H --> J["성공 상태 유지"]

```
<img width="1853" height="294" alt="image" src="https://github.com/user-attachments/assets/a75709fb-f19c-4a14-92dc-1a5f3acfb455" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 즐겨찾기·좋아요·스페이스 생성·입장 버튼에 인증 상태 전달 및 인증 게이트 추가(비인증 시 로그인 안내 토스트 표시)
  * 생성 버튼 클릭 시 클라이언트 네비게이션 방식으로 동작 변경

* **Bug Fixes**
  * 서버 액션 응답을 표준화({ ok, data | error })하여 인증/실패 처리 개선 및 롤백 시나리오 보완
  * 좋아요 낙관적 업데이트의 롤백 및 오류 처리 강화

* **Chores**
  * 검색·즐겨찾기·조회 흐름에 성능 타이밍(console.time) 및 로깅 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->