### PR TITLE
[refactor] 모임 생성/랜딩 페이지 - 1차 QA 피드백 반영

### DIFF
--- a/apps/web/src/_pages/landing/index.ts
+++ b/apps/web/src/_pages/landing/index.ts
@@ -2,3 +2,4 @@ export * from "./assets";
 export { CATEGORIES } from "./constants";
 export { CategoryCard } from "./ui/category-card";
 export { IcoChevronDownDouble } from "./ui/ico-chevron-down-double";
+export { LandingCtaButton } from "./ui/landing-cta-button";

--- a/apps/web/src/_pages/landing/ui/landing-cta-button.tsx
+++ b/apps/web/src/_pages/landing/ui/landing-cta-button.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Button } from "@ui/components";
+import { useRouter } from "next/navigation";
+import { ROUTES } from "@/shared/config/routes";
+
+type Props = {
+  size: "medium" | "large";
+  className?: string;
+};
+
+export const LandingCtaButton = ({ size, className }: Props) => {
+  const router = useRouter();
+  const handleClick = () => router.push(ROUTES.search);
+
+  return (
+    <Button size={size} className={className} onClick={handleClick}>
+      모임 찾아보기
+    </Button>
+  );
+};

--- a/apps/web/src/_pages/moim-create/use-cases/moim-create.test.ts
+++ b/apps/web/src/_pages/moim-create/use-cases/moim-create.test.ts
@@ -1,17 +1,45 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as memberQueries from "@/entities/member";
 import * as spaceQueries from "@/entities/spaces/queries";
 import type { ApiClient } from "@/shared/api";
 import { createMoim } from "./moim-create";
 
+vi.mock("@/shared/api/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/api/server")>();
+  return {
+    ...actual,
+    isAuth: vi.fn().mockResolvedValue({ authenticated: true, userId: 1 }),
+  };
+});
+
 vi.mock("@/shared/db", () => ({ db: {} }));
+vi.mock("@/entities/member", () => ({
+  insertSpaceMember: vi.fn(),
+}));
 vi.mock("@/entities/spaces/queries");
 
 const mockInsertSpace = vi.mocked(spaceQueries.insertSpace);
+const mockInsertSpaceMember = vi.mocked(memberQueries.insertSpaceMember);
+
 const mockCreate = vi.fn();
+const mockGetUser = vi.fn().mockResolvedValue({
+  ok: true,
+  data: {
+    id: 1,
+    teamId: "moum-zip-dev",
+    email: "test@example.com",
+    name: "테스트",
+    companyName: null,
+    image: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  },
+});
 
 type AuthedApi = ApiClient;
 const mockAuthedApi = {
   meetings: { create: mockCreate },
+  user: { getUser: mockGetUser },
 } as unknown as AuthedApi;
 
 const mockDeps = {
@@ -55,10 +83,21 @@ describe("createMoim", () => {
     mockInsertSpace.mockResolvedValue(mockSpaceResult);
   });
 
-  it("외부 API 호출 후 SPACE DB에 저장", async () => {
+  it("외부 API 호출 후 SPACE DB에 저장 후 멤버로 등록", async () => {
     const result = await createMoim(baseInput, mockDeps);
     expect(mockCreate).toHaveBeenCalledOnce();
     expect(mockInsertSpace).toHaveBeenCalledOnce();
+    expect(mockInsertSpaceMember).toHaveBeenCalledOnce();
+    expect(mockInsertSpaceMember).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spaceId: mockSpaceResult.id,
+        userId: 1,
+        role: "manager",
+        nickname: "테스트",
+        email: "test@example.com",
+        avatarUrl: null,
+      }),
+    );
     expect(result.meeting.id).toBe(20);
     expect(result.space.slug).toBe("20");
   });
@@ -72,5 +111,11 @@ describe("createMoim", () => {
     mockCreate.mockResolvedValue({ ok: false });
     await expect(createMoim(baseInput, mockDeps)).rejects.toThrow();
     expect(mockInsertSpace).not.toHaveBeenCalled();
+    expect(mockInsertSpaceMember).not.toHaveBeenCalled();
+  });
+
+  it("스페이스 멤버 등록 실패 시 에러를 던짐", async () => {
+    mockInsertSpaceMember.mockRejectedValue(new Error("스페이스 멤버 저장에 실패했습니다."));
+    await expect(createMoim(baseInput, mockDeps)).rejects.toThrow("스페이스 멤버 저장에 실패했습니다.");
   });
 });

--- a/apps/web/src/_pages/moim-create/use-cases/moim-create.ts
+++ b/apps/web/src/_pages/moim-create/use-cases/moim-create.ts
@@ -1,6 +1,7 @@
+import { insertSpaceMember } from "@/entities/member";
 import { insertSpace } from "@/entities/spaces/queries";
 import type { MoimCreateFormValues } from "@/features/moim-create/model/schema";
-import { getApi } from "@/shared/api/server";
+import { getApi, isAuth } from "@/shared/api/server";
 
 type Deps = {
   getAuthApi?: () => ReturnType<typeof getApi>;
@@ -18,17 +19,21 @@ export async function createMoim(formData: MoimCreateFormValues, { getAuthApi = 
     registrationEnd: new Date(`${formData.deadlineDate}T${formData.deadlineTime}`).toISOString(), // deadlineDate
   };
 
-  // meetings API 호출 → MEETING 생성
+  // 인증
   const authedApi = await getAuthApi();
+  const { userId } = await isAuth();
+  if (userId == null) throw new Error("로그인이 필요합니다.");
+
+  const userRes = await authedApi.user.getUser();
+  if (!userRes.ok || !userRes.data) throw new Error("유저 정보를 불러오지 못했습니다.");
+  const me = userRes.data;
+
+  // 외부 API 호출 → MEETING 생성
   const res = await authedApi.meetings.create(meetingPayload);
-
-  if (!res.ok) {
-    throw new Error("모임 생성에 실패했습니다.");
-  }
-
+  if (!res.ok) throw new Error("모임 생성에 실패했습니다.");
   const meeting = res.data as { id: number };
 
-  // 외부 API 응답 meetingId로 SPACE DB 저장
+  // SPACE DB 저장
   const space = await insertSpace({
     id: String(meeting.id),
     slug: String(meeting.id),
@@ -37,6 +42,17 @@ export async function createMoim(formData: MoimCreateFormValues, { getAuthApi = 
     themeColor: formData.themeColor,
     status: "ongoing",
     modules: formData.options ?? [],
+  });
+
+  // 스페이스 멤버 등록
+  await insertSpaceMember({
+    id: crypto.randomUUID(),
+    spaceId: space.id,
+    userId,
+    role: "manager",
+    nickname: me.name,
+    email: me.email,
+    avatarUrl: me.image,
   });
 
   return { meeting, space };

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@ui/components";
 import Image from "next/image";
 import {
   bgDoubleOval,
@@ -8,6 +7,7 @@ import {
   CategoryCard,
   heroImage,
   IcoChevronDownDouble,
+  LandingCtaButton,
   spaceLg,
   spaceMd,
   spaceSm,
@@ -28,12 +28,8 @@ export default function Home() {
               <span className="block">작은 한 걸음도 혼자가 아니면 가벼워집니다.</span>
               <span className="block">당신의 첫 모임, 모음.zip이 도와드릴게요.</span>
             </p>
-            <Button size="medium" className="mt-12 min-w-0 max-w-[132px] md:hidden">
-              모임 찾아보기
-            </Button>
-            <Button size="large" className="mt-12 hidden w-[168px] min-w-0 md:inline-flex">
-              모임 찾아보기
-            </Button>
+            <LandingCtaButton size="medium" className="mt-12 min-w-0 max-w-[132px] md:hidden" />
+            <LandingCtaButton size="large" className="mt-12 hidden w-[168px] min-w-0 md:inline-flex" />
           </div>
           <Image
             src={heroImage}
@@ -116,12 +112,8 @@ export default function Home() {
             <span className="relative block text-gray-950">혼자 시작하기 어려웠던 일들,</span>
             <span className="relative mt-2 block text-green-600">모음.zip에서 함께 해요</span>
           </h2>
-          <Button size="medium" className="min-w-0 max-w-[140px] md:hidden">
-            모임 찾아보기
-          </Button>
-          <Button size="large" className="hidden w-[168px] min-w-0 md:block">
-            모임 찾아보기
-          </Button>
+          <LandingCtaButton size="medium" className="min-w-0 max-w-[140px] md:hidden" />
+          <LandingCtaButton size="large" className="hidden w-[168px] min-w-0 md:block" />
         </div>
       </section>
     </>

--- a/apps/web/src/entities/member/index.ts
+++ b/apps/web/src/entities/member/index.ts
@@ -5,4 +5,4 @@ export type { Member, NewMember } from "@/shared/db/scheme";
 export type { MemberRole, RolePermissions } from "./model/types";
 export { ROLE_LABEL, ROLE_PERMISSIONS } from "./model/types";
 
-export { getSpaceMembers } from "./queries";
+export { getSpaceMembers, insertSpaceMember } from "./queries";

--- a/apps/web/src/entities/member/queries.ts
+++ b/apps/web/src/entities/member/queries.ts
@@ -1,9 +1,15 @@
 import { eq } from "drizzle-orm";
 import { db } from "@/shared/db";
-import { spaceMembers } from "@/shared/db/scheme";
+import { type NewMember, spaceMembers } from "@/shared/db/scheme";
 
 export const getSpaceMembers = async (spaceId: string) => {
   return db.query.spaceMembers.findMany({
     where: eq(spaceMembers.spaceId, spaceId),
   });
 };
+
+export async function insertSpaceMember(data: NewMember) {
+  const [row] = await db.insert(spaceMembers).values(data).returning();
+  if (!row) throw new Error("스페이스 멤버 저장에 실패했습니다.");
+  return row;
+}

--- a/apps/web/src/features/moim-create/model/schema.test.ts
+++ b/apps/web/src/features/moim-create/model/schema.test.ts
@@ -58,4 +58,22 @@ describe("moimCreateSchema", () => {
     expect(result.success).toBe(false);
     expect(result.error?.issues[0].message).toBe("1명 이상 입력해주세요.");
   });
+
+  it("capacity가 최대 정원 1000을 초과하면 실패", () => {
+    const result = moimCreateSchema.safeParse({ ...baseInput, capacity: 1001 });
+    expect(result.success).toBe(false);
+    const capacityIssue = result.error?.issues.find((issue) => issue.path[0] === "capacity");
+    expect(capacityIssue?.message).toBe("최대 1000명까지 가능합니다.");
+  });
+
+  it("capacity가 최대 정원과 같으면 성공", () => {
+    const result = moimCreateSchema.safeParse({ ...baseInput, capacity: 1000 });
+    expect(result.success).toBe(true);
+  });
+
+  it("capacity가 음수이면 실패", () => {
+    const result = moimCreateSchema.safeParse({ ...baseInput, capacity: -1 });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].message).toBe("1명 이상 입력해주세요.");
+  });
 });

--- a/apps/web/src/features/moim-create/model/schema.ts
+++ b/apps/web/src/features/moim-create/model/schema.ts
@@ -11,7 +11,10 @@ export const moimCreateSchema = z
   .object({
     type: z.enum(["study", "project"], { error: "모임 종류를 선택해주세요." }),
     name: z.string().min(1, "모임 이름을 입력해주세요."),
-    capacity: z.number({ error: "모집 정원을 입력해주세요." }).min(1, "1명 이상 입력해주세요."),
+    capacity: z
+      .number({ error: "모집 정원을 입력해주세요." })
+      .min(1, "1명 이상 입력해주세요.")
+      .max(1000, "최대 1000명까지 가능합니다."),
     description: z.string().min(1, "모임 설명을 입력해주세요."),
     image: z.string().min(1, "이미지를 첨부해주세요."),
     location: z.enum(["online", "offline"], { error: "장소를 선택해주세요." }),

--- a/apps/web/src/features/moim-create/ui/moim-create-form.tsx
+++ b/apps/web/src/features/moim-create/ui/moim-create-form.tsx
@@ -97,7 +97,7 @@ export const MoimCreateForm = () => {
             message={errors.capacity?.message}
             {...register("capacity", { valueAsNumber: true })}
             onKeyDown={(e) => {
-              if (e.key === "-" || e.key === "e") e.preventDefault();
+              if (["-", "e", "E", "+"].includes(e.key)) e.preventDefault();
             }}
           />
 

--- a/apps/web/src/features/moim-create/ui/moim-create-form.tsx
+++ b/apps/web/src/features/moim-create/ui/moim-create-form.tsx
@@ -91,9 +91,14 @@ export const MoimCreateForm = () => {
             placeholder="숫자만 입력해주세요"
             type="number"
             required
+            min={1}
+            max={1000}
             isDestructive={!!errors.capacity}
             message={errors.capacity?.message}
             {...register("capacity", { valueAsNumber: true })}
+            onKeyDown={(e) => {
+              if (e.key === "-" || e.key === "e") e.preventDefault();
+            }}
           />
 
           <Controller


### PR DESCRIPTION
## 📌 Summary

1차 QA의 개선 사항을 반영했습니다.
- close #77


## 📄 Tasks
- `LandingCtaButton` 컴포넌트 분리 및 `/search` 페이지 라우팅 연결
- 모임 정원 입력 시 음수 및 지수 키 입력 UI 레벨에서 차단
  (`e` 허용 시 `1e-5` 같은 지수 표기가 숫자로 파싱되어 유효성 검증 우회가 가능하다고 합니다.)
- 모임 정원 `capacity` 최대 1000명 제한 및 에러 메시지 추가 (API CreateMeeting 스펙 반영)
- createMoim 실행 순서 정리
   - 인증(isAuth) → 프로필(getUser) → 외부 모임 생성 API → insertSpace → insertSpaceMember
- 모임 생성자를 `manager` role로 `space_members` 테이블에 자동 등록

## 👀 To Reviewer

- `space_members` PK `id`는 스키마상 `text`라 `crypto.randomUUID()`를 사용했습니다.
- 랜딩 CTA 버튼은 디자인 시스템 `Button`에 `href` 및 `asChild`가 없어 `router.push` 방식으로 구현했습니다. 접근성 요구사항이 생기면 `asChild` + `Link` 방식으로 교체 예정입니다.

## 📸 Screenshot

모임 생성 후 `space_members` 테이블에 생성자가 `manager` role로 자동 등록된 것을 확인
<img width="1808" height="545" alt="스크린샷 2026-03-30 오후 1 29 51" src="https://github.com/user-attachments/assets/ee8a5c48-362d-4480-921c-c95f43134217" />

스페이스 멤버 페이지에서 생성자가 Manager로 노출되는 것을 확인
<img width="1671" height="700" alt="스크린샷 2026-03-30 오후 1 39 24" src="https://github.com/user-attachments/assets/977b816b-5cf9-4302-9111-731d8532bb66" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 랜딩 페이지 호출 버튼 컴포넌트 추가 및 랜딩 UI에 적용
  * 스페이스 멤버 등록 기능 추가(모임 생성 시 생성자 자동 등록)

* **Bug Fixes**
  * 모임 생성 시 인증 및 사용자 정보 검증 강화
  * 정원 입력값 검증 강화(최대 1000명, 입력 제약)

* **Tests**
  * 인증/멤버 등록 흐름과 정원 경계 관련 테스트 추가 및 보완
<!-- end of auto-generated comment: release notes by coderabbit.ai -->