### PR TITLE
[refactor] 모임 상세 페이지 1차 QA 반영

### DIFF
--- a/apps/web/src/_pages/moim-detail/actions.ts
+++ b/apps/web/src/_pages/moim-detail/actions.ts
@@ -134,6 +134,7 @@ export async function joinMeetingAction(
     };
   }
 }
+
 export async function deleteMeetingAction(meetingId: number): Promise<ActionResult<{ meetingId: number }>> {
   const { authenticated } = await isAuth();
 

--- a/apps/web/src/_pages/moim-detail/index.ts
+++ b/apps/web/src/_pages/moim-detail/index.ts
@@ -1,4 +1,5 @@
 export { CompactCard } from "./ui/compact-card";
 export { DescriptionSection } from "./ui/description-section";
 export { InformationContainer } from "./ui/information-container";
+export { MoimDetailClient } from "./ui/moim-detail-client";
 export { PersonnelContainer } from "./ui/personnel-container";

--- a/apps/web/src/_pages/moim-detail/model/mapper.ts
+++ b/apps/web/src/_pages/moim-detail/model/mapper.ts
@@ -218,7 +218,13 @@ export function getIsJoined(participantsResponse: ParticipantsListResponse, curr
 }
 
 function getIsLiked<T>(meeting: T) {
-  return (meeting as T & { isFavorited?: boolean | null }).isFavorited ?? false;
+  const target = meeting as T & {
+    isFavorited?: boolean | null;
+    isLiked?: boolean | null;
+    liked?: boolean | null;
+  };
+
+  return target.isFavorited ?? target.isLiked ?? target.liked ?? false;
 }
 
 function getMeetingActionState(params: {

--- a/apps/web/src/_pages/moim-detail/ui/compact-card.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/compact-card.tsx
@@ -13,7 +13,7 @@ interface CompactCardProps {
   locationIcon?: ReactNode;
   locationText: string;
   isLiked?: boolean;
-  onLikeClick?: () => void;
+  onLikeClick?: () => boolean | Promise<boolean>;
 }
 
 export function CompactCard({

--- a/apps/web/src/_pages/moim-detail/ui/compact-card.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/compact-card.tsx
@@ -39,9 +39,7 @@ export function CompactCard({
         {image}
 
         <div className="absolute right-3 bottom-3 max-sm:right-2.5 max-sm:bottom-2.5">
-          <LikeButton isLiked={isLiked} size="md" className="shrink-0 max-sm:hidden" onClick={onLikeClick} />
-
-          <LikeButton isLiked={isLiked} size="sm" className="hidden shrink-0 max-sm:flex" onClick={onLikeClick} />
+          <LikeButton isLiked={isLiked} className="h-10 w-10 shrink-0 sm:h-12 sm:w-12" onClick={onLikeClick} />
         </div>
       </div>
 

--- a/apps/web/src/_pages/moim-detail/ui/compact-card.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/compact-card.tsx
@@ -39,7 +39,7 @@ export function CompactCard({
         {image}
 
         <div className="absolute right-3 bottom-3 max-sm:right-2.5 max-sm:bottom-2.5">
-          <LikeButton isLiked={isLiked} className="h-10 w-10 shrink-0 sm:h-12 sm:w-12" onClick={onLikeClick} />
+          <LikeButton isLiked={isLiked} onClick={onLikeClick} />
         </div>
       </div>
 

--- a/apps/web/src/_pages/moim-detail/ui/information-container.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/information-container.tsx
@@ -270,11 +270,7 @@ export function InformationContainer({
 
           <div className="mt-auto w-full">
             <div className="flex w-full items-center gap-4 max-sm:gap-2">
-              <LikeButton
-                isLiked={data.isLiked}
-                className="h-10 w-10 shrink-0 sm:h-[60px] sm:w-[60px]"
-                onClick={handleLikeClick}
-              />
+              <LikeButton isLiked={data.isLiked} onClick={handleLikeClick} />
 
               <div className="flex min-w-0 flex-1 items-center gap-4 max-sm:gap-2">{renderActionButtons()}</div>
             </div>

--- a/apps/web/src/_pages/moim-detail/ui/information-container.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/information-container.tsx
@@ -45,6 +45,7 @@ export function InformationContainer({
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
   const isManager = viewType === "manager";
+  const isClosedMeeting = data.status === "full";
 
   const tagItems = [
     {
@@ -97,7 +98,7 @@ export function InformationContainer({
   };
 
   const handleMainButtonClick = () => {
-    if (isManager) {
+    if (isManager || isClosedMeeting) {
       return;
     }
 
@@ -128,12 +129,18 @@ export function InformationContainer({
     onLoginAction?.();
   };
 
-  const renderPrimaryButton = (label: string, onClick: () => void, variant: "primary" | "secondary" = "primary") => (
+  const renderPrimaryButton = (
+    label: string,
+    onClick: () => void,
+    variant: "primary" | "secondary" = "primary",
+    disabled = false,
+  ) => (
     <>
       <Button
         type="button"
         variant={variant}
         size="large"
+        disabled={disabled}
         className={cn(
           "min-w-0 flex-1 max-sm:hidden",
           variant === "secondary" && "border border-primary bg-white text-green-600",
@@ -147,6 +154,7 @@ export function InformationContainer({
         type="button"
         variant={variant}
         size="small"
+        disabled={disabled}
         className={cn(
           "hidden min-w-0 flex-1 max-sm:inline-flex",
           variant === "secondary" && "border border-primary bg-white text-green-600",
@@ -175,6 +183,10 @@ export function InformationContainer({
           {renderPrimaryButton("스페이스 입장", handleEnterSpaceClick)}
         </>
       );
+    }
+
+    if (isClosedMeeting) {
+      return renderPrimaryButton("모집 마감", () => {}, "primary", true);
     }
 
     return renderPrimaryButton("신청하기", handleMainButtonClick);

--- a/apps/web/src/_pages/moim-detail/ui/information-container.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/information-container.tsx
@@ -45,7 +45,7 @@ export function InformationContainer({
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
   const isManager = viewType === "manager";
-  const isClosedMeeting = data.status === "full";
+  const isClosedMeeting = data.status === "full" || data.status === "canceled";
 
   const tagItems = [
     {
@@ -190,7 +190,7 @@ export function InformationContainer({
     }
 
     if (isClosedMeeting) {
-      return renderPrimaryButton("모집 마감", () => {}, "primary", true);
+      return renderPrimaryButton(data.status === "canceled" ? "모집 취소" : "모집 마감", () => {}, "primary", true);
     }
 
     return renderPrimaryButton("신청하기", handleMainButtonClick);

--- a/apps/web/src/_pages/moim-detail/ui/information-container.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/information-container.tsx
@@ -171,13 +171,13 @@ export function InformationContainer({
     if (isParticipating) {
       return (
         <>
-          {renderPrimaryButton("참여 취소하기", handleMainButtonClick, "secondary")}
+          {renderPrimaryButton("신청 취소하기", handleMainButtonClick, "secondary")}
           {renderPrimaryButton("스페이스 입장", handleEnterSpaceClick)}
         </>
       );
     }
 
-    return renderPrimaryButton("참여하기", handleMainButtonClick);
+    return renderPrimaryButton("신청하기", handleMainButtonClick);
   };
 
   return (
@@ -256,15 +256,7 @@ export function InformationContainer({
             <div className="flex w-full items-center gap-4 max-sm:gap-2">
               <LikeButton
                 isLiked={data.isLiked}
-                size="lg"
-                className="shrink-0 max-sm:hidden"
-                onClick={handleLikeClick}
-              />
-
-              <LikeButton
-                isLiked={data.isLiked}
-                size="sm"
-                className="hidden shrink-0 max-sm:flex"
+                className="h-10 w-10 shrink-0 sm:h-[60px] sm:w-[60px]"
                 onClick={handleLikeClick}
               />
 

--- a/apps/web/src/_pages/moim-detail/ui/information-container.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/information-container.tsx
@@ -185,7 +185,7 @@ export function InformationContainer({
       <section className={cn("w-full", className)}>
         <article
           className={cn(
-            "mx-auto flex w-full max-w-[630px] flex-col items-start gap-2.5",
+            "mx-auto flex w-full max-w-[630px] flex-col items-start gap-6",
             "rounded-[32px] bg-white",
             "px-10 pt-8.5 pb-8",
             "max-sm:rounded-[20px]",

--- a/apps/web/src/_pages/moim-detail/ui/information-container.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/information-container.tsx
@@ -18,7 +18,7 @@ interface InformationContainerProps {
   viewType?: ViewType;
   isLoggedIn?: boolean;
   isParticipating?: boolean;
-  onToggleLike?: () => void;
+  onToggleLike?: () => boolean | Promise<boolean>;
   onParticipateToggle?: (meetingId: number, nextParticipating: boolean) => void;
   onShare?: (meetingId: number) => void;
   onEdit?: (meetingId: number) => void;
@@ -88,17 +88,21 @@ export function InformationContainer({
     },
   ].filter((item) => item.label);
 
-  const handleLikeClick = () => {
+  const handleLikeClick = async (): Promise<boolean> => {
     if (!isLoggedIn) {
       setIsLoginModalOpen(true);
-      return;
+      return false;
     }
 
-    onToggleLike?.();
+    if (!onToggleLike) {
+      return true;
+    }
+
+    return await onToggleLike();
   };
 
   const handleMainButtonClick = () => {
-    if (isManager || isClosedMeeting) {
+    if (isManager || (isClosedMeeting && !isParticipating)) {
       return;
     }
 

--- a/apps/web/src/_pages/moim-detail/ui/like-button.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/like-button.tsx
@@ -1,37 +1,29 @@
 "use client";
 
 import { UtilityButton } from "@ui/components";
+import { cn } from "@ui/lib/utils";
 
 import HeartActiveIcon from "../assets/svg/heart-active.svg";
 import HeartDefaultIcon from "../assets/svg/heart-default.svg";
 
 interface LikeButtonProps {
   isLiked?: boolean;
-  size?: "sm" | "md" | "lg";
   className?: string;
   onClick?: () => void;
 }
 
-export const LikeButton = ({ isLiked = false, size = "md", className, onClick }: LikeButtonProps) => {
+export const LikeButton = ({ isLiked = false, className, onClick }: LikeButtonProps) => {
   const Icon = isLiked ? HeartActiveIcon : HeartDefaultIcon;
 
   return (
     <UtilityButton
-      size={size}
       active={isLiked}
       aria-label={isLiked ? "좋아요 취소" : "좋아요 추가"}
-      className={className}
       onClick={onClick}
-      icon={(iconSize) => (
-        <span
-          className="inline-flex shrink-0 items-center justify-center leading-none"
-          style={{ width: `${iconSize}px`, height: `${iconSize}px` }}
-        >
-          <Icon
-            aria-hidden="true"
-            className="block shrink-0"
-            style={{ width: `${iconSize}px`, height: `${iconSize}px` }}
-          />
+      className={cn("h-10 w-10 sm:h-[60px] sm:w-[60px]", className)}
+      icon={() => (
+        <span className="inline-flex items-center justify-center">
+          <Icon aria-hidden="true" className="block h-5 w-5 sm:h-8 sm:w-8" />
         </span>
       )}
     />

--- a/apps/web/src/_pages/moim-detail/ui/like-button.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/like-button.tsx
@@ -2,6 +2,7 @@
 
 import { UtilityButton } from "@ui/components";
 import { cn } from "@ui/lib/utils";
+import { useEffect, useState, useTransition } from "react";
 
 import HeartActiveIcon from "../assets/svg/heart-active.svg";
 import HeartDefaultIcon from "../assets/svg/heart-default.svg";
@@ -9,18 +10,41 @@ import HeartDefaultIcon from "../assets/svg/heart-default.svg";
 interface LikeButtonProps {
   isLiked?: boolean;
   className?: string;
-  onClick?: () => void;
+  onClick?: () => void | Promise<void>;
 }
 
 export const LikeButton = ({ isLiked = false, className, onClick }: LikeButtonProps) => {
-  const Icon = isLiked ? HeartActiveIcon : HeartDefaultIcon;
+  const [optimisticIsLiked, setOptimisticIsLiked] = useState(isLiked);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setOptimisticIsLiked(isLiked);
+  }, [isLiked]);
+
+  const handleClick = () => {
+    const previousIsLiked = optimisticIsLiked;
+    const nextIsLiked = !previousIsLiked;
+
+    setOptimisticIsLiked(nextIsLiked);
+
+    startTransition(async () => {
+      try {
+        await onClick?.();
+      } catch {
+        setOptimisticIsLiked(previousIsLiked);
+      }
+    });
+  };
+
+  const Icon = optimisticIsLiked ? HeartActiveIcon : HeartDefaultIcon;
 
   return (
     <UtilityButton
-      active={isLiked}
-      aria-label={isLiked ? "좋아요 취소" : "좋아요 추가"}
-      onClick={onClick}
-      className={cn("h-10 w-10 sm:h-[60px] sm:w-[60px]", className)}
+      active={optimisticIsLiked}
+      aria-label={optimisticIsLiked ? "좋아요 취소" : "좋아요 추가"}
+      onClick={handleClick}
+      disabled={isPending}
+      className={cn("h-10 w-10 shrink-0 sm:h-[60px] sm:w-[60px]", className)}
       icon={() => (
         <span className="inline-flex items-center justify-center">
           <Icon aria-hidden="true" className="block h-5 w-5 sm:h-8 sm:w-8" />

--- a/apps/web/src/_pages/moim-detail/ui/like-button.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/like-button.tsx
@@ -10,7 +10,7 @@ import HeartDefaultIcon from "../assets/svg/heart-default.svg";
 interface LikeButtonProps {
   isLiked?: boolean;
   className?: string;
-  onClick?: () => void | Promise<void>;
+  onClick?: () => boolean | Promise<boolean>;
 }
 
 export const LikeButton = ({ isLiked = false, className, onClick }: LikeButtonProps) => {
@@ -29,7 +29,10 @@ export const LikeButton = ({ isLiked = false, className, onClick }: LikeButtonPr
 
     startTransition(async () => {
       try {
-        await onClick?.();
+        const succeeded = (await onClick?.()) ?? true;
+        if (!succeeded) {
+          setOptimisticIsLiked(previousIsLiked);
+        }
       } catch {
         setOptimisticIsLiked(previousIsLiked);
       }

--- a/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { CompactCard, DescriptionSection, InformationContainer, PersonnelContainer } from "@/_pages/moim-detail";
+import {
+  deleteMeetingAction,
+  favoriteMeetingAction,
+  getSpaceSlugByMeetingAction,
+  joinMeetingAction,
+} from "@/_pages/moim-detail/actions";
+import LocationIcon from "@/_pages/moim-detail/assets/svg/location.svg";
+import type { InformationData, PersonnelData, RecommendedMeetingData } from "@/_pages/moim-detail/model/types";
+import { ROUTES } from "@/shared/config/routes";
+
+interface MoimDetailClientProps {
+  meetingId: number;
+  currentUserId: number | null;
+  initialInformationData: InformationData;
+  initialDescription: string;
+  initialPersonnelData: PersonnelData;
+  initialRecommendedMeetings: RecommendedMeetingData[];
+  initialIsParticipating: boolean;
+}
+
+export function MoimDetailClient({
+  meetingId,
+  currentUserId,
+  initialInformationData,
+  initialDescription,
+  initialPersonnelData,
+  initialRecommendedMeetings,
+  initialIsParticipating,
+}: MoimDetailClientProps) {
+  const router = useRouter();
+
+  const [informationData, setInformationData] = useState<InformationData>(initialInformationData);
+  const [recommendedMeetings, setRecommendedMeetings] = useState<RecommendedMeetingData[]>(initialRecommendedMeetings);
+  const [isParticipating, setIsParticipating] = useState(initialIsParticipating);
+
+  const [isFavoritePending, setIsFavoritePending] = useState(false);
+  const [isJoinPending, setIsJoinPending] = useState(false);
+  const [isEnterSpacePending, setIsEnterSpacePending] = useState(false);
+  const [isDeletePending, setIsDeletePending] = useState(false);
+  const [pendingRecommendedLikeIds, setPendingRecommendedLikeIds] = useState<number[]>([]);
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, []);
+
+  const handleToggleMeetingLike = async () => {
+    if (isFavoritePending) {
+      return;
+    }
+
+    if (!currentUserId) {
+      router.push(`/login?redirect=%2Fmoim-detail%2F${meetingId}`);
+      return;
+    }
+
+    setIsFavoritePending(true);
+
+    try {
+      const result = await favoriteMeetingAction(informationData.id, informationData.isLiked);
+
+      if (!result.ok) {
+        alert(result.message);
+        return;
+      }
+
+      setInformationData((prev) => ({
+        ...prev,
+        isLiked: result.data.isLiked,
+      }));
+    } catch (error) {
+      alert("좋아요 처리 중 오류가 발생했습니다.");
+    } finally {
+      setIsFavoritePending(false);
+    }
+  };
+
+  const handleParticipateToggle = async (_id: number, nextParticipating: boolean) => {
+    if (isJoinPending) {
+      return;
+    }
+
+    const previousIsJoined = isParticipating;
+
+    setIsJoinPending(true);
+    setIsParticipating(nextParticipating);
+
+    try {
+      const result = await joinMeetingAction(informationData.id, previousIsJoined);
+
+      if (!result.ok) {
+        setIsParticipating(previousIsJoined);
+        alert(result.message);
+        return;
+      }
+
+      setIsParticipating(result.data.isJoined);
+    } catch (error) {
+      setIsParticipating(previousIsJoined);
+      alert("참여 처리 중 오류가 발생했습니다.");
+    } finally {
+      setIsJoinPending(false);
+    }
+  };
+
+  const handleShare = async (_id: number) => {
+    try {
+      const shareUrl = `${window.location.origin}/moim-detail/${meetingId}`;
+
+      if (!navigator.clipboard) {
+        const textArea = document.createElement("textarea");
+        textArea.value = shareUrl;
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textArea);
+        alert("모임 링크가 복사되었습니다.");
+        return;
+      }
+
+      await navigator.clipboard.writeText(shareUrl);
+      alert("모임 링크가 복사되었습니다.");
+    } catch (error) {
+      alert("링크 복사에 실패했습니다.");
+    }
+  };
+
+  const handleEnterSpace = async (targetMeetingId: number) => {
+    if (isEnterSpacePending) {
+      return;
+    }
+
+    setIsEnterSpacePending(true);
+
+    try {
+      const result = await getSpaceSlugByMeetingAction(targetMeetingId);
+
+      if (!result.ok) {
+        alert(result.message);
+        return;
+      }
+
+      router.push(`/${result.data.slug}`);
+    } catch (error) {
+      alert("스페이스 입장 중 오류가 발생했습니다.");
+    } finally {
+      setIsEnterSpacePending(false);
+    }
+  };
+
+  const handleEdit = (_id: number) => {
+    // TODO: 수정 페이지 연결 시 경로 교체
+  };
+
+  const handleDelete = async (_id: number) => {
+    if (isDeletePending) {
+      return;
+    }
+
+    setIsDeletePending(true);
+
+    try {
+      const result = await deleteMeetingAction(informationData.id);
+
+      if (!result.ok) {
+        alert(result.message);
+        return;
+      }
+
+      alert("모임이 삭제되었습니다.");
+      router.replace(ROUTES.search);
+    } catch (error) {
+      alert("모임 삭제 중 오류가 발생했습니다.");
+    } finally {
+      setIsDeletePending(false);
+    }
+  };
+
+  const handleLoginAction = () => {
+    router.push(`/login?redirect=%2Fmoim-detail%2F${meetingId}`);
+  };
+
+  const handleMoveToMeetingDetail = (targetMeetingId: number) => {
+    router.push(`/moim-detail/${targetMeetingId}`);
+  };
+
+  const handleToggleRecommendedLike = async (targetMeetingId: number) => {
+    if (pendingRecommendedLikeIds.includes(targetMeetingId)) {
+      return;
+    }
+
+    if (!currentUserId) {
+      router.push(`/login?redirect=%2Fmoim-detail%2F${meetingId}`);
+      return;
+    }
+
+    const targetMeeting = recommendedMeetings.find((meeting) => meeting.id === targetMeetingId);
+
+    if (!targetMeeting) {
+      return;
+    }
+
+    setPendingRecommendedLikeIds((prev) => [...prev, targetMeetingId]);
+
+    try {
+      const result = await favoriteMeetingAction(targetMeeting.id, targetMeeting.isLiked);
+
+      if (!result.ok) {
+        alert(result.message);
+        return;
+      }
+
+      setRecommendedMeetings((prev) =>
+        prev.map((meeting) =>
+          meeting.id === targetMeetingId
+            ? {
+                ...meeting,
+                isLiked: result.data.isLiked,
+              }
+            : meeting,
+        ),
+      );
+    } catch (error) {
+      alert("좋아요 처리 중 오류가 발생했습니다.");
+    } finally {
+      setPendingRecommendedLikeIds((prev) => prev.filter((id) => id !== targetMeetingId));
+    }
+  };
+
+  const viewType = informationData.viewerRole === "manager" ? "manager" : "member";
+
+  return (
+    <div className="min-h-screen">
+      <main className="mx-auto flex w-full max-w-[1312px] flex-col gap-[78px] px-5 pt-6 pb-24 md:px-6 md:pt-10 xl:px-10">
+        <section className="grid grid-cols-1 gap-5 md:grid-cols-2">
+          <div className="relative mx-auto max-h-[443px] w-full max-w-[630px] overflow-hidden rounded-[20px] md:rounded-[32px]">
+            {informationData.image ? (
+              <img src={informationData.image} alt="모임 대표 이미지" className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400 text-sm">
+                이미지 영역
+              </div>
+            )}
+          </div>
+
+          <div className="flex h-full w-full flex-col gap-5">
+            <InformationContainer
+              data={informationData}
+              viewType={viewType}
+              isLoggedIn={!!currentUserId}
+              isParticipating={isParticipating}
+              onToggleLike={handleToggleMeetingLike}
+              onParticipateToggle={handleParticipateToggle}
+              onEnterSpace={handleEnterSpace}
+              onShare={handleShare}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+              onLoginAction={handleLoginAction}
+            />
+
+            <PersonnelContainer data={initialPersonnelData} />
+          </div>
+        </section>
+
+        <DescriptionSection description={initialDescription} />
+
+        <section className="flex flex-col gap-5">
+          <h2 className="font-semibold text-2xl text-black leading-[1.4]">이런 모임은 어때요?</h2>
+
+          <div className="grid grid-cols-2 gap-x-4 gap-y-5 xl:grid-cols-4">
+            {recommendedMeetings.map((meeting) => {
+              const isRecommendedLikePending = pendingRecommendedLikeIds.includes(meeting.id);
+
+              return (
+                <div
+                  key={meeting.id}
+                  role="link"
+                  tabIndex={0}
+                  className="cursor-pointer"
+                  onClick={(event) => {
+                    const target = event.target as HTMLElement;
+
+                    if (target.closest("button")) {
+                      return;
+                    }
+
+                    handleMoveToMeetingDetail(meeting.id);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter") {
+                      return;
+                    }
+
+                    const target = event.target as HTMLElement;
+
+                    if (target.closest("button")) {
+                      return;
+                    }
+
+                    event.preventDefault();
+                    handleMoveToMeetingDetail(meeting.id);
+                  }}
+                >
+                  <CompactCard
+                    image={
+                      meeting.image ? (
+                        <img src={meeting.image} alt={meeting.title} className="h-full w-full object-cover" />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400 text-xs md:text-sm">
+                          이미지 영역
+                        </div>
+                      )
+                    }
+                    deadlineLabel={meeting.deadlineLabel}
+                    dateLabel={meeting.dateLabel}
+                    timeLabel={meeting.timeLabel}
+                    title={meeting.title}
+                    locationIcon={<LocationIcon />}
+                    locationText={meeting.locationText}
+                    isLiked={meeting.isLiked}
+                    onLikeClick={() => {
+                      if (isRecommendedLikePending) {
+                        return;
+                      }
+
+                      void handleToggleRecommendedLike(meeting.id);
+                    }}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
@@ -48,14 +48,14 @@ export function MoimDetailClient({
     window.scrollTo({ top: 0, left: 0, behavior: "auto" });
   }, []);
 
-  const handleToggleMeetingLike = async () => {
+  const handleToggleMeetingLike = async (): Promise<boolean> => {
     if (isFavoritePending) {
-      return;
+      return false;
     }
 
     if (!currentUserId) {
       router.push(`/login?redirect=%2Fmoim-detail%2F${meetingId}`);
-      return;
+      return false;
     }
 
     setIsFavoritePending(true);
@@ -65,15 +65,18 @@ export function MoimDetailClient({
 
       if (!result.ok) {
         alert(result.message);
-        return;
+        return false;
       }
 
       setInformationData((prev) => ({
         ...prev,
         isLiked: result.data.isLiked,
       }));
+
+      return true;
     } catch (error) {
       alert("좋아요 처리 중 오류가 발생했습니다.");
+      return false;
     } finally {
       setIsFavoritePending(false);
     }
@@ -188,20 +191,20 @@ export function MoimDetailClient({
     router.push(`/moim-detail/${targetMeetingId}`);
   };
 
-  const handleToggleRecommendedLike = async (targetMeetingId: number) => {
+  const handleToggleRecommendedLike = async (targetMeetingId: number): Promise<boolean> => {
     if (pendingRecommendedLikeIds.includes(targetMeetingId)) {
-      return;
+      return false;
     }
 
     if (!currentUserId) {
       router.push(`/login?redirect=%2Fmoim-detail%2F${meetingId}`);
-      return;
+      return false;
     }
 
     const targetMeeting = recommendedMeetings.find((meeting) => meeting.id === targetMeetingId);
 
     if (!targetMeeting) {
-      return;
+      return false;
     }
 
     setPendingRecommendedLikeIds((prev) => [...prev, targetMeetingId]);
@@ -211,7 +214,7 @@ export function MoimDetailClient({
 
       if (!result.ok) {
         alert(result.message);
-        return;
+        return false;
       }
 
       setRecommendedMeetings((prev) =>
@@ -224,8 +227,11 @@ export function MoimDetailClient({
             : meeting,
         ),
       );
+
+      return true;
     } catch (error) {
       alert("좋아요 처리 중 오류가 발생했습니다.");
+      return false;
     } finally {
       setPendingRecommendedLikeIds((prev) => prev.filter((id) => id !== targetMeetingId));
     }
@@ -324,10 +330,10 @@ export function MoimDetailClient({
                     isLiked={meeting.isLiked}
                     onLikeClick={() => {
                       if (isRecommendedLikePending) {
-                        return;
+                        return false;
                       }
 
-                      void handleToggleRecommendedLike(meeting.id);
+                      return handleToggleRecommendedLike(meeting.id);
                     }}
                   />
                 </div>

--- a/apps/web/src/_pages/moim-detail/ui/personnel-container.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/personnel-container.tsx
@@ -64,7 +64,7 @@ export function PersonnelContainer({ data, className }: PersonnelContainerProps)
             </div>
 
             <Badge variant="confirmed" container="none">
-              {statusLabel !== "모집중" && <CheckCircleIcon className="size-6 max-sm:size-4.5" />}
+              {statusLabel === "개설확정" && <CheckCircleIcon className="size-6 max-sm:size-4.5" />}
               <span className="font-semibold text-base max-sm:font-medium max-sm:text-xs">
                 {statusLabel || "모집중"}
               </span>

--- a/apps/web/src/_pages/moim-detail/use-cases/join-meeting.ts
+++ b/apps/web/src/_pages/moim-detail/use-cases/join-meeting.ts
@@ -11,7 +11,7 @@ interface JoinMeetingDeps {
 
 export async function joinMeeting({ meetingId, isJoined }: JoinMeetingInput, { meetingsApi }: JoinMeetingDeps) {
   if (isJoined) {
-    await meetingsApi.cancelJoin(meetingId);
+    const response = await meetingsApi.cancelJoin(meetingId);
 
     return {
       meetingId,
@@ -19,7 +19,7 @@ export async function joinMeeting({ meetingId, isJoined }: JoinMeetingInput, { m
     };
   }
 
-  await meetingsApi.join(meetingId);
+  const response = await meetingsApi.join(meetingId);
 
   return {
     meetingId,

--- a/apps/web/src/app/(main)/moim-detail/[meetingId]/page.tsx
+++ b/apps/web/src/app/(main)/moim-detail/[meetingId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { LoadingIndicator } from "@ui/components";
 import { useRouter } from "next/navigation";
 import { use, useEffect, useState } from "react";
 import { CompactCard, DescriptionSection, InformationContainer, PersonnelContainer } from "@/_pages/moim-detail";
@@ -342,7 +343,7 @@ export default function MoimDetailPage({ params }: PageProps) {
   }
 
   if (isLoading) {
-    return <div>불러오는 중...</div>;
+    return <LoadingIndicator fullScreen text="모임 정보를 불러오는 중" />;
   }
 
   if (errorMessage) {

--- a/apps/web/src/app/(main)/moim-detail/[meetingId]/page.tsx
+++ b/apps/web/src/app/(main)/moim-detail/[meetingId]/page.tsx
@@ -1,17 +1,8 @@
-"use client";
-
 import { LoadingIndicator } from "@ui/components";
-import { useRouter } from "next/navigation";
-import { use, useEffect, useState } from "react";
-import { CompactCard, DescriptionSection, InformationContainer, PersonnelContainer } from "@/_pages/moim-detail";
-import {
-  deleteMeetingAction,
-  favoriteMeetingAction,
-  getCurrentUser,
-  getSpaceSlugByMeetingAction,
-  joinMeetingAction,
-} from "@/_pages/moim-detail/actions";
-import LocationIcon from "@/_pages/moim-detail/assets/svg/location.svg";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { MoimDetailClient } from "@/_pages/moim-detail";
+import { getCurrentUser } from "@/_pages/moim-detail/actions";
 import {
   getIsJoined,
   mapMeetingDetailToDescription,
@@ -20,9 +11,7 @@ import {
   mapMeetingToRecommendedMeetingData,
   mapParticipantsToParticipantData,
 } from "@/_pages/moim-detail/model/mapper";
-import type { InformationData, PersonnelData, RecommendedMeetingData } from "@/_pages/moim-detail/model/types";
-import { api } from "@/shared/api";
-import { ROUTES } from "@/shared/config/routes";
+import { getApi } from "@/shared/api/server";
 
 interface PageProps {
   params: Promise<{
@@ -30,435 +19,104 @@ interface PageProps {
   }>;
 }
 
-export default function MoimDetailPage({ params }: PageProps) {
-  const router = useRouter();
-  const { meetingId } = use(params);
-  const numericMeetingId = Number(meetingId);
+interface MoimDetailContentProps {
+  meetingId: number;
+}
 
-  const [informationData, setInformationData] = useState<InformationData | null>(null);
-  const [description, setDescription] = useState("");
-  const [personnelData, setPersonnelData] = useState<PersonnelData | null>(null);
-  const [recommendedMeetings, setRecommendedMeetings] = useState<RecommendedMeetingData[]>([]);
-  const [isParticipating, setIsParticipating] = useState(false);
-  const [currentUserId, setCurrentUserId] = useState<number | null>(null);
+async function MoimDetailContent({ meetingId }: MoimDetailContentProps) {
+  const currentUserResult = await getCurrentUser();
+  const currentUserId = currentUserResult.ok ? currentUserResult.data.id : null;
 
-  const [isLoading, setIsLoading] = useState(true);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const apiClient = await getApi();
 
-  const [isFavoritePending, setIsFavoritePending] = useState(false);
-  const [isJoinPending, setIsJoinPending] = useState(false);
-  const [isEnterSpacePending, setIsEnterSpacePending] = useState(false);
-  const [isDeletePending, setIsDeletePending] = useState(false);
-  const [pendingRecommendedLikeIds, setPendingRecommendedLikeIds] = useState<number[]>([]);
+  const [meetingDetailResponse, participantsResponse, meetingsResponse] = await Promise.all([
+    apiClient.meetings.getDetail(meetingId),
+    apiClient.meetings.participants.getList(meetingId),
+    apiClient.meetings.getList(),
+  ]);
 
-  useEffect(() => {
-    let cancelled = false;
+  const meetingDetail = "data" in meetingDetailResponse ? meetingDetailResponse.data : meetingDetailResponse;
 
-    if (Number.isNaN(numericMeetingId)) {
-      setIsLoading(false);
-      setErrorMessage("유효하지 않은 meetingId입니다.");
-      return;
-    }
+  const participantsList = "data" in participantsResponse ? participantsResponse.data : participantsResponse;
 
-    const fetchMeetingDetail = async () => {
-      setIsLoading(true);
-      setErrorMessage(null);
+  const meetingsList = "data" in meetingsResponse ? meetingsResponse.data : meetingsResponse;
 
-      try {
-        const [currentUserResult, meetingDetailResponse, participantsResponse, meetingsResponse] = await Promise.all([
-          getCurrentUser(),
-          api.meetings.getDetail(numericMeetingId),
-          api.meetings.participants.getList(numericMeetingId),
-          api.meetings.getList(),
-        ]);
-
-        if (cancelled) {
-          return;
-        }
-
-        const resolvedCurrentUserId = currentUserResult.ok ? currentUserResult.data.id : null;
-
-        const meetingDetail = "data" in meetingDetailResponse ? meetingDetailResponse.data : meetingDetailResponse;
-        const participantsList = "data" in participantsResponse ? participantsResponse.data : participantsResponse;
-        const meetingsList = "data" in meetingsResponse ? meetingsResponse.data : meetingsResponse;
-
-        if (!meetingDetail || !participantsList || !meetingsList) {
-          throw new Error("API 응답이 예상된 형식이 아닙니다.");
-        }
-
-        const isJoined = getIsJoined(participantsList, resolvedCurrentUserId);
-
-        const mappedInformationData = mapMeetingDetailToInformationData({
-          meeting: meetingDetail,
-          currentUserId: resolvedCurrentUserId,
-          isJoined,
-        });
-
-        const mappedDescription = mapMeetingDetailToDescription(meetingDetail);
-        const personnelBaseData = mapMeetingDetailToPersonnelBaseData(meetingDetail);
-        const mappedParticipants = mapParticipantsToParticipantData(participantsList);
-
-        setCurrentUserId(resolvedCurrentUserId);
-        setInformationData(mappedInformationData);
-        setDescription(mappedDescription);
-        setPersonnelData({
-          ...personnelBaseData,
-          participants: mappedParticipants,
-          extraCount: Math.max(meetingDetail.participantCount - mappedParticipants.length, 0),
-        });
-        setIsParticipating(isJoined);
-
-        setRecommendedMeetings(
-          [...meetingsList.data]
-            .filter((meeting) => meeting.id !== numericMeetingId)
-            .sort((a, b) => {
-              const aSameType = a.type === meetingDetail.type ? 1 : 0;
-              const bSameType = b.type === meetingDetail.type ? 1 : 0;
-
-              if (aSameType !== bSameType) {
-                return bSameType - aSameType;
-              }
-
-              const aSameHost = a.hostId === meetingDetail.hostId ? 1 : 0;
-              const bSameHost = b.hostId === meetingDetail.hostId ? 1 : 0;
-
-              if (aSameHost !== bSameHost) {
-                return bSameHost - aSameHost;
-              }
-
-              const aDeadline = a.registrationEnd ? new Date(a.registrationEnd).getTime() : Number.MAX_SAFE_INTEGER;
-              const bDeadline = b.registrationEnd ? new Date(b.registrationEnd).getTime() : Number.MAX_SAFE_INTEGER;
-
-              if (aDeadline !== bDeadline) {
-                return aDeadline - bDeadline;
-              }
-
-              return b.participantCount - a.participantCount;
-            })
-            .slice(0, 4)
-            .map((meeting) => mapMeetingToRecommendedMeetingData(meeting)),
-        );
-      } catch (error) {
-        if (!cancelled) {
-          setErrorMessage("모임 정보를 불러오는데 실패했습니다.");
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    void fetchMeetingDetail();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [numericMeetingId]);
-
-  const handleToggleMeetingLike = async () => {
-    if (!informationData || isFavoritePending) {
-      return;
-    }
-
-    setIsFavoritePending(true);
-
-    try {
-      const result = await favoriteMeetingAction(informationData.id, informationData.isLiked);
-
-      if (!result.ok) {
-        alert(result.message);
-        return;
-      }
-
-      setInformationData((prev) =>
-        prev
-          ? {
-              ...prev,
-              isLiked: result.data.isLiked,
-            }
-          : prev,
-      );
-    } catch (error) {
-      alert("좋아요 처리 중 오류가 발생했습니다.");
-    } finally {
-      setIsFavoritePending(false);
-    }
-  };
-
-  const handleParticipateToggle = async (_id: number, nextParticipating: boolean) => {
-    if (!informationData || isJoinPending) {
-      return;
-    }
-
-    const previousIsJoined = isParticipating;
-
-    setIsJoinPending(true);
-    setIsParticipating(nextParticipating);
-
-    try {
-      const result = await joinMeetingAction(informationData.id, previousIsJoined);
-
-      if (!result.ok) {
-        setIsParticipating(previousIsJoined);
-        alert(result.message);
-        return;
-      }
-
-      setIsParticipating(result.data.isJoined);
-    } catch (error) {
-      setIsParticipating(previousIsJoined);
-      alert("참여 처리 중 오류가 발생했습니다.");
-    } finally {
-      setIsJoinPending(false);
-    }
-  };
-
-  const handleShare = async (_id: number) => {
-    try {
-      const shareUrl = `${window.location.origin}/moim-detail/${numericMeetingId}`;
-
-      if (!navigator.clipboard) {
-        const textArea = document.createElement("textarea");
-        textArea.value = shareUrl;
-        document.body.appendChild(textArea);
-        textArea.select();
-        document.execCommand("copy");
-        document.body.removeChild(textArea);
-        alert("모임 링크가 복사되었습니다.");
-        return;
-      }
-
-      await navigator.clipboard.writeText(shareUrl);
-      alert("모임 링크가 복사되었습니다.");
-    } catch (error) {
-      alert("링크 복사에 실패했습니다.");
-    }
-  };
-
-  const handleEnterSpace = async (meetingId: number) => {
-    if (isEnterSpacePending) {
-      return;
-    }
-
-    setIsEnterSpacePending(true);
-
-    try {
-      const result = await getSpaceSlugByMeetingAction(meetingId);
-
-      if (!result.ok) {
-        alert(result.message);
-        return;
-      }
-
-      router.push(`/${result.data.slug}`);
-    } catch (error) {
-      alert("스페이스 입장 중 오류가 발생했습니다.");
-    } finally {
-      setIsEnterSpacePending(false);
-    }
-  };
-
-  const handleEdit = (_id: number) => {
-    // TODO: 수정 페이지 연결 시 경로 교체
-  };
-
-  const handleDelete = async (_id: number) => {
-    if (!informationData || isDeletePending) {
-      return;
-    }
-
-    setIsDeletePending(true);
-
-    try {
-      const result = await deleteMeetingAction(informationData.id);
-
-      if (!result.ok) {
-        alert(result.message);
-        return;
-      }
-
-      alert("모임이 삭제되었습니다.");
-      router.replace(ROUTES.search);
-    } catch (error) {
-      alert("모임 삭제 중 오류가 발생했습니다.");
-    } finally {
-      setIsDeletePending(false);
-    }
-  };
-
-  const handleLoginAction = () => {
-    router.push(`/login?redirect=%2Fmoim-detail%2F${numericMeetingId}`);
-  };
-
-  const handleMoveToMeetingDetail = (meetingId: number) => {
-    router.push(`/moim-detail/${meetingId}`);
-  };
-
-  const handleToggleRecommendedLike = async (meetingId: number) => {
-    if (pendingRecommendedLikeIds.includes(meetingId)) {
-      return;
-    }
-
-    if (!currentUserId) {
-      router.push(`/login?redirect=%2Fmoim-detail%2F${numericMeetingId}`);
-      return;
-    }
-
-    const targetMeeting = recommendedMeetings.find((meeting) => meeting.id === meetingId);
-
-    if (!targetMeeting) {
-      return;
-    }
-
-    setPendingRecommendedLikeIds((prev) => [...prev, meetingId]);
-
-    try {
-      const result = await favoriteMeetingAction(targetMeeting.id, targetMeeting.isLiked);
-
-      if (!result.ok) {
-        alert(result.message);
-        return;
-      }
-
-      setRecommendedMeetings((prev) =>
-        prev.map((meeting) =>
-          meeting.id === meetingId
-            ? {
-                ...meeting,
-                isLiked: result.data.isLiked,
-              }
-            : meeting,
-        ),
-      );
-    } catch (error) {
-      alert("좋아요 처리 중 오류가 발생했습니다.");
-    } finally {
-      setPendingRecommendedLikeIds((prev) => prev.filter((id) => id !== meetingId));
-    }
-  };
-
-  if (Number.isNaN(numericMeetingId)) {
-    return <div>유효하지 않은 meetingId입니다.</div>;
-  }
-
-  if (isLoading) {
-    return <LoadingIndicator fullScreen text="모임 정보를 불러오는 중" />;
-  }
-
-  if (errorMessage) {
-    return <div>{errorMessage}</div>;
-  }
-
-  if (!informationData || !personnelData) {
+  if (!meetingDetail || !participantsList || !meetingsList) {
     return <div>모임 정보를 표시할 수 없습니다.</div>;
   }
 
-  const viewType = informationData.viewerRole === "manager" ? "manager" : "member";
+  const isJoined = getIsJoined(participantsList, currentUserId);
+
+  const informationData = mapMeetingDetailToInformationData({
+    meeting: meetingDetail,
+    currentUserId,
+    isJoined,
+  });
+
+  const description = mapMeetingDetailToDescription(meetingDetail);
+
+  const personnelBaseData = mapMeetingDetailToPersonnelBaseData(meetingDetail);
+  const mappedParticipants = mapParticipantsToParticipantData(participantsList);
+
+  const personnelData = {
+    ...personnelBaseData,
+    participants: mappedParticipants,
+    extraCount: Math.max(meetingDetail.participantCount - mappedParticipants.length, 0),
+  };
+
+  const recommendedMeetings = [...meetingsList.data]
+    .filter((meeting) => meeting.id !== meetingId)
+    .sort((a, b) => {
+      const aSameType = a.type === meetingDetail.type ? 1 : 0;
+      const bSameType = b.type === meetingDetail.type ? 1 : 0;
+
+      if (aSameType !== bSameType) {
+        return bSameType - aSameType;
+      }
+
+      const aSameHost = a.hostId === meetingDetail.hostId ? 1 : 0;
+      const bSameHost = b.hostId === meetingDetail.hostId ? 1 : 0;
+
+      if (aSameHost !== bSameHost) {
+        return bSameHost - aSameHost;
+      }
+
+      const aDeadline = a.registrationEnd ? new Date(a.registrationEnd).getTime() : Number.MAX_SAFE_INTEGER;
+      const bDeadline = b.registrationEnd ? new Date(b.registrationEnd).getTime() : Number.MAX_SAFE_INTEGER;
+
+      if (aDeadline !== bDeadline) {
+        return aDeadline - bDeadline;
+      }
+
+      return b.participantCount - a.participantCount;
+    })
+    .slice(0, 4)
+    .map((meeting) => mapMeetingToRecommendedMeetingData(meeting));
 
   return (
-    <div className="min-h-screen">
-      <main className="mx-auto flex w-full max-w-[1312px] flex-col gap-[78px] px-5 pt-6 pb-24 md:px-6 md:pt-10 xl:px-10">
-        <section className="grid grid-cols-1 gap-5 md:grid-cols-2">
-          <div className="relative h-full min-h-[190px] w-full overflow-hidden rounded-[20px] md:min-h-[260px] md:rounded-[32px] xl:min-h-[443px]">
-            {informationData.image ? (
-              <img src={informationData.image} alt="모임 대표 이미지" className="h-full w-full object-cover" />
-            ) : (
-              <div className="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400 text-sm">
-                이미지 영역
-              </div>
-            )}
-          </div>
+    <MoimDetailClient
+      meetingId={meetingId}
+      currentUserId={currentUserId}
+      initialInformationData={informationData}
+      initialDescription={description}
+      initialPersonnelData={personnelData}
+      initialRecommendedMeetings={recommendedMeetings}
+      initialIsParticipating={isJoined}
+    />
+  );
+}
 
-          <div className="flex h-full w-full flex-col gap-5">
-            <InformationContainer
-              data={informationData}
-              viewType={viewType}
-              isLoggedIn={!!currentUserId}
-              isParticipating={isParticipating}
-              onToggleLike={handleToggleMeetingLike}
-              onParticipateToggle={handleParticipateToggle}
-              onEnterSpace={handleEnterSpace}
-              onShare={handleShare}
-              onEdit={handleEdit}
-              onDelete={handleDelete}
-              onLoginAction={handleLoginAction}
-            />
+export default async function MoimDetailPage({ params }: PageProps) {
+  const { meetingId } = await params;
+  const numericMeetingId = Number(meetingId);
 
-            <PersonnelContainer data={personnelData} />
-          </div>
-        </section>
+  if (Number.isNaN(numericMeetingId)) {
+    notFound();
+  }
 
-        <DescriptionSection description={description} />
-
-        <section className="flex flex-col gap-5">
-          <h2 className="font-semibold text-2xl text-black leading-[1.4]">이런 모임은 어때요?</h2>
-
-          <div className="grid grid-cols-2 gap-x-4 gap-y-5 xl:grid-cols-4">
-            {recommendedMeetings.map((meeting) => {
-              const isRecommendedLikePending = pendingRecommendedLikeIds.includes(meeting.id);
-
-              return (
-                <div
-                  key={meeting.id}
-                  role="link"
-                  tabIndex={0}
-                  className="cursor-pointer"
-                  onClick={(event) => {
-                    const target = event.target as HTMLElement;
-
-                    if (target.closest("button")) {
-                      return;
-                    }
-
-                    handleMoveToMeetingDetail(meeting.id);
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key !== "Enter") {
-                      return;
-                    }
-
-                    const target = event.target as HTMLElement;
-
-                    if (target.closest("button")) {
-                      return;
-                    }
-
-                    event.preventDefault();
-                    handleMoveToMeetingDetail(meeting.id);
-                  }}
-                >
-                  <CompactCard
-                    image={
-                      meeting.image ? (
-                        <img src={meeting.image} alt={meeting.title} className="h-full w-full object-cover" />
-                      ) : (
-                        <div className="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400 text-xs md:text-sm">
-                          이미지 영역
-                        </div>
-                      )
-                    }
-                    deadlineLabel={meeting.deadlineLabel}
-                    dateLabel={meeting.dateLabel}
-                    timeLabel={meeting.timeLabel}
-                    title={meeting.title}
-                    locationIcon={<LocationIcon />}
-                    locationText={meeting.locationText}
-                    isLiked={meeting.isLiked}
-                    onLikeClick={() => {
-                      if (isRecommendedLikePending) {
-                        return;
-                      }
-
-                      void handleToggleRecommendedLike(meeting.id);
-                    }}
-                  />
-                </div>
-              );
-            })}
-          </div>
-        </section>
-      </main>
-    </div>
+  return (
+    <Suspense fallback={<LoadingIndicator fullScreen text="모임 정보를 불러오는 중" />}>
+      <MoimDetailContent meetingId={numericMeetingId} />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/(main)/moim-detail/[meetingId]/page.tsx
+++ b/apps/web/src/app/(main)/moim-detail/[meetingId]/page.tsx
@@ -29,81 +29,85 @@ async function MoimDetailContent({ meetingId }: MoimDetailContentProps) {
 
   const apiClient = await getApi();
 
-  const [meetingDetailResponse, participantsResponse, meetingsResponse] = await Promise.all([
-    apiClient.meetings.getDetail(meetingId),
-    apiClient.meetings.participants.getList(meetingId),
-    apiClient.meetings.getList(),
-  ]);
+  try {
+    const [meetingDetailResponse, participantsResponse, meetingsResponse] = await Promise.all([
+      apiClient.meetings.getDetail(meetingId),
+      apiClient.meetings.participants.getList(meetingId),
+      apiClient.meetings.getList(),
+    ]);
 
-  const meetingDetail = "data" in meetingDetailResponse ? meetingDetailResponse.data : meetingDetailResponse;
+    const meetingDetail = "data" in meetingDetailResponse ? meetingDetailResponse.data : meetingDetailResponse;
 
-  const participantsList = "data" in participantsResponse ? participantsResponse.data : participantsResponse;
+    const participantsList = "data" in participantsResponse ? participantsResponse.data : participantsResponse;
 
-  const meetingsList = "data" in meetingsResponse ? meetingsResponse.data : meetingsResponse;
+    const meetingsList = "data" in meetingsResponse ? meetingsResponse.data : meetingsResponse;
 
-  if (!meetingDetail || !participantsList || !meetingsList) {
+    if (!meetingDetail || !participantsList || !meetingsList) {
+      return <div>모임 정보를 표시할 수 없습니다.</div>;
+    }
+
+    const isJoined = getIsJoined(participantsList, currentUserId);
+
+    const informationData = mapMeetingDetailToInformationData({
+      meeting: meetingDetail,
+      currentUserId,
+      isJoined,
+    });
+
+    const description = mapMeetingDetailToDescription(meetingDetail);
+
+    const personnelBaseData = mapMeetingDetailToPersonnelBaseData(meetingDetail);
+    const mappedParticipants = mapParticipantsToParticipantData(participantsList);
+
+    const personnelData = {
+      ...personnelBaseData,
+      participants: mappedParticipants,
+      extraCount: Math.max(meetingDetail.participantCount - mappedParticipants.length, 0),
+    };
+
+    const recommendedMeetings = [...meetingsList.data]
+      .filter((meeting) => meeting.id !== meetingId)
+      .sort((a, b) => {
+        const aSameType = a.type === meetingDetail.type ? 1 : 0;
+        const bSameType = b.type === meetingDetail.type ? 1 : 0;
+
+        if (aSameType !== bSameType) {
+          return bSameType - aSameType;
+        }
+
+        const aSameHost = a.hostId === meetingDetail.hostId ? 1 : 0;
+        const bSameHost = b.hostId === meetingDetail.hostId ? 1 : 0;
+
+        if (aSameHost !== bSameHost) {
+          return bSameHost - aSameHost;
+        }
+
+        const aDeadline = a.registrationEnd ? new Date(a.registrationEnd).getTime() : Number.MAX_SAFE_INTEGER;
+        const bDeadline = b.registrationEnd ? new Date(b.registrationEnd).getTime() : Number.MAX_SAFE_INTEGER;
+
+        if (aDeadline !== bDeadline) {
+          return aDeadline - bDeadline;
+        }
+
+        return b.participantCount - a.participantCount;
+      })
+      .slice(0, 4)
+      .map((meeting) => mapMeetingToRecommendedMeetingData(meeting));
+
+    return (
+      <MoimDetailClient
+        meetingId={meetingId}
+        currentUserId={currentUserId}
+        initialInformationData={informationData}
+        initialDescription={description}
+        initialPersonnelData={personnelData}
+        initialRecommendedMeetings={recommendedMeetings}
+        initialIsParticipating={isJoined}
+      />
+    );
+  } catch {
     return <div>모임 정보를 표시할 수 없습니다.</div>;
   }
-
-  const isJoined = getIsJoined(participantsList, currentUserId);
-
-  const informationData = mapMeetingDetailToInformationData({
-    meeting: meetingDetail,
-    currentUserId,
-    isJoined,
-  });
-
-  const description = mapMeetingDetailToDescription(meetingDetail);
-
-  const personnelBaseData = mapMeetingDetailToPersonnelBaseData(meetingDetail);
-  const mappedParticipants = mapParticipantsToParticipantData(participantsList);
-
-  const personnelData = {
-    ...personnelBaseData,
-    participants: mappedParticipants,
-    extraCount: Math.max(meetingDetail.participantCount - mappedParticipants.length, 0),
-  };
-
-  const recommendedMeetings = [...meetingsList.data]
-    .filter((meeting) => meeting.id !== meetingId)
-    .sort((a, b) => {
-      const aSameType = a.type === meetingDetail.type ? 1 : 0;
-      const bSameType = b.type === meetingDetail.type ? 1 : 0;
-
-      if (aSameType !== bSameType) {
-        return bSameType - aSameType;
-      }
-
-      const aSameHost = a.hostId === meetingDetail.hostId ? 1 : 0;
-      const bSameHost = b.hostId === meetingDetail.hostId ? 1 : 0;
-
-      if (aSameHost !== bSameHost) {
-        return bSameHost - aSameHost;
-      }
-
-      const aDeadline = a.registrationEnd ? new Date(a.registrationEnd).getTime() : Number.MAX_SAFE_INTEGER;
-      const bDeadline = b.registrationEnd ? new Date(b.registrationEnd).getTime() : Number.MAX_SAFE_INTEGER;
-
-      if (aDeadline !== bDeadline) {
-        return aDeadline - bDeadline;
-      }
-
-      return b.participantCount - a.participantCount;
-    })
-    .slice(0, 4)
-    .map((meeting) => mapMeetingToRecommendedMeetingData(meeting));
-
-  return (
-    <MoimDetailClient
-      meetingId={meetingId}
-      currentUserId={currentUserId}
-      initialInformationData={informationData}
-      initialDescription={description}
-      initialPersonnelData={personnelData}
-      initialRecommendedMeetings={recommendedMeetings}
-      initialIsParticipating={isJoined}
-    />
-  );
 }
 
 export default async function MoimDetailPage({ params }: PageProps) {

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -10,6 +10,7 @@ export * from "./ui/gnb";
 export * from "./ui/input-field";
 export * from "./ui/input-image";
 export * from "./ui/input-text-area";
+export * from "./ui/loading-indicator";
 export * from "./ui/pagination";
 export * from "./ui/progress-bar";
 export * from "./ui/sheet";

--- a/packages/ui/src/components/ui/loading-indicator.tsx
+++ b/packages/ui/src/components/ui/loading-indicator.tsx
@@ -12,7 +12,7 @@ interface LoadingIndicatorProps {
 export function LoadingIndicator({ text = "불러오는 중", fullScreen = false, className }: LoadingIndicatorProps) {
   return (
     <div className={cn("flex items-center justify-center px-5", fullScreen && "min-h-screen", className)}>
-      <div className="flex min-h-screen items-center justify-center px-5">
+      <div className="flex items-center justify-center">
         <div className="flex flex-col items-center gap-3">
           <p className="font-semibold text-base text-gray-900">{text}</p>
           <div className="flex items-center gap-1">

--- a/packages/ui/src/components/ui/loading-indicator.tsx
+++ b/packages/ui/src/components/ui/loading-indicator.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { cn } from "@ui/lib/utils";
+
+interface LoadingIndicatorProps {
+  text?: string;
+  description?: string;
+  fullScreen?: boolean;
+  className?: string;
+}
+
+export function LoadingIndicator({ text = "불러오는 중", fullScreen = false, className }: LoadingIndicatorProps) {
+  return (
+    <div className={cn("flex items-center justify-center px-5", fullScreen && "min-h-screen", className)}>
+      <div className="flex min-h-screen items-center justify-center px-5">
+        <div className="flex flex-col items-center gap-3">
+          <p className="font-semibold text-base text-gray-900">{text}</p>
+          <div className="flex items-center gap-1">
+            <span className="h-2 w-2 animate-[soft-bounce_1s_ease-in-out_infinite] rounded-full bg-primary" />
+            <span className="h-2 w-2 animate-[soft-bounce_1s_ease-in-out_infinite_0.15s] rounded-full bg-primary/80" />
+            <span className="h-2 w-2 animate-[soft-bounce_1s_ease-in-out_infinite_0.3s] rounded-full bg-primary/60" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/ui/loading-indicator.tsx
+++ b/packages/ui/src/components/ui/loading-indicator.tsx
@@ -4,7 +4,6 @@ import { cn } from "@ui/lib/utils";
 
 interface LoadingIndicatorProps {
   text?: string;
-  description?: string;
   fullScreen?: boolean;
   className?: string;
 }

--- a/packages/ui/src/global.css
+++ b/packages/ui/src/global.css
@@ -315,3 +315,18 @@
     var(--color-personnel-gradient-end) 100%
   );
 }
+
+/* 로딩 인디케이터 애니메이션 */
+@keyframes soft-bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.5;
+    scale: 0.9;
+  }
+  50% {
+    transform: translateY(-6px);
+    opacity: 1;
+    scale: 1;
+  }
+}


### PR DESCRIPTION
## 📌 Summary
모임 상세 페이지 1차 QA 수정사항 반영했습니다.

- close #76 

## 📄 Tasks
### 기능 수정
- 모임 찜하기 상태 유지 로직 수정
- 모임 참여하기 API 연동 및 상태 반영 로직 개선
- 모임 상세 페이지 진입 시 스크롤을 최상단으로 초기화하도록 수정

### UI 수정
- 모임 상세 페이지 진입 시(모임 불러오는 중) 다소 로딩 시간이 길게 느껴져 간단한 로딩 인디케이터 추가했습니다.
  → 공통 컴포넌트로 분리해서 혹시 필요한 부분이 있으시면 편하게 사용해 주세요!
     (`packages/ui/src/components/ui/loading-indicator.tsx`)
- 모임 썸네일 이미지 사이즈 조절 (max: 630x443)
- 모집 마감 상태일 경우 신청 버튼 비활성화 처리
- 모집 상태 UI 분기 처리 (개설확정일 때만 텍스트 앞에 `CheckCircleIcon` 표시)
- 찜 버튼 반응형 UI 수정 (모바일 환경에서 클릭시 하트 아이콘이 사라지는 문제 해결)

### 구조 개선
- 모임 상세 페이지의 `page.tsx`를 서버/클라이언트 역할에 맞게 분리했습니다.
  - `app/(main)/moim-detail/[meetingId]/page.tsx`
  → 서버 컴포넌트로, 데이터 fetching 및 초기 데이터 전달 역할 담당
  - `_pages/moim-detail/ui/moim-detail-client.tsx`
  → 클라이언트 컴포넌트로, UI 렌더링 및 사용자 인터랙션 처리 담당

## 👀 To Reviewer
- 모임 수정하기 기능은 구현 예정입니다.
- UI는 피그마 디자인과 최대한 동일하게 구현했는데 크거나 어색하게 느껴지는 부분이 있다면 피드백 부탁드립니다!

## 📸 Screenshot

https://github.com/user-attachments/assets/30e076cc-46e4-42f1-b77b-3dd640fa61f7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 페이지 로딩 중 표시되는 로딩 인디케이터 추가
  * 모임 상세용 클라이언트 렌더링 컴포넌트 공개

* **Improvements**
  * 좋아요 즉시 반영(낙관적 UI) 및 클릭 중 중복 방지
  * 반응형 좋아요 버튼 표현 통합 및 간소화
  * 모집 완료 시 주요 버튼 비활성화 및 레이블 개선
  * 참여/취소 라벨 및 레이아웃 간격 정리

* **Bug Fixes**
  * 좋아요 상태 판별 로직 확장(다양한 필드 인식)
  * 일부 상태 아이콘 표시 조건 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->