### PR TITLE
[feat] 모임 수정하기 구현

### DIFF
--- a/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
@@ -155,8 +155,8 @@ export function MoimDetailClient({
     }
   };
 
-  const handleEdit = (_id: number) => {
-    // TODO: 수정 페이지 연결 시 경로 교체
+  const handleEdit = (targetMeetingId: number) => {
+    router.push(`${ROUTES.moimEdit}/${targetMeetingId}`);
   };
 
   const handleDelete = async (_id: number) => {
@@ -188,7 +188,7 @@ export function MoimDetailClient({
   };
 
   const handleMoveToMeetingDetail = (targetMeetingId: number) => {
-    router.push(`/moim-detail/${targetMeetingId}`);
+    router.push(`${ROUTES.moimDetail}/${targetMeetingId}`);
   };
 
   const handleToggleRecommendedLike = async (targetMeetingId: number): Promise<boolean> => {

--- a/apps/web/src/_pages/moim-edit/actions.ts
+++ b/apps/web/src/_pages/moim-edit/actions.ts
@@ -24,7 +24,7 @@ export async function updateMoimAction(_: UpdateMoimActionState, formData: FormD
   // 2. meetingId 꺼내기 (없으면 에러)
   const meetingId = Number(formData.get("meetingId"));
 
-  if (!meetingId) {
+  if (!meetingId || meetingId < 1 || !Number.isInteger(meetingId)) {
     return {
       ok: false,
       error: "잘못된 요청입니다. (meetingId 없음)",

--- a/apps/web/src/_pages/moim-edit/actions.ts
+++ b/apps/web/src/_pages/moim-edit/actions.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import { isRedirectError } from "next/dist/client/components/redirect-error";
+import { redirect } from "next/navigation";
+import { parseMoimFormData } from "@/_pages/moim-create/lib/parse-moim-form-data";
+import { updateMoim } from "@/_pages/moim-edit/use-cases/moim-update";
+import type { MoimCreateFormValues } from "@/features/moim-create/model/schema";
+import { isAuth } from "@/shared/api/server";
+import { ROUTES } from "@/shared/config/routes";
+
+export type UpdateMoimActionState = {
+  ok: false;
+  error: string;
+} | null;
+
+export async function updateMoimAction(_: UpdateMoimActionState, formData: FormData): Promise<UpdateMoimActionState> {
+  // 1. 로그인 체크
+  const { authenticated } = await isAuth();
+
+  if (!authenticated) {
+    redirect(ROUTES.login);
+  }
+
+  // 2. meetingId 꺼내기 (없으면 에러)
+  const meetingId = Number(formData.get("meetingId"));
+
+  if (!meetingId) {
+    return {
+      ok: false,
+      error: "잘못된 요청입니다. (meetingId 없음)",
+    };
+  }
+
+  // 3. FormData → MoimCreateFormValues로 파싱 (실패하면 에러 메시지 반환)
+  let parsed: MoimCreateFormValues;
+
+  try {
+    parsed = parseMoimFormData(formData);
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "입력값이 올바르지 않습니다.",
+    };
+  }
+
+  // 4. use-case 호출
+  try {
+    await updateMoim({
+      meetingId,
+      data: parsed,
+    });
+
+    // 5. 성공 시 상세 페이지로 이동
+    redirect(`${ROUTES.moimDetail}/${meetingId}`);
+  } catch (e) {
+    if (isRedirectError(e)) throw e;
+
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "모임 수정에 실패했습니다.",
+    };
+  }
+}

--- a/apps/web/src/_pages/moim-edit/use-cases/moim-update.test.ts
+++ b/apps/web/src/_pages/moim-edit/use-cases/moim-update.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { spaceQueries } from "@/entities/spaces";
+import type { ApiClient } from "@/shared/api";
+import { updateMoim } from "./moim-update";
+
+vi.mock("@/shared/api/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/api/server")>();
+  return {
+    ...actual,
+    isAuth: vi.fn().mockResolvedValue({ authenticated: true, userId: 1 }),
+  };
+});
+
+vi.mock("@/shared/db", () => ({ db: {} }));
+vi.mock("@/entities/spaces");
+
+const mockUpdateSpace = vi.mocked(spaceQueries.updateByMeetingId);
+
+const mockUpdate = vi.fn();
+
+type AuthedApi = ApiClient;
+const mockAuthedApi = {
+  meetings: { update: mockUpdate },
+} as unknown as AuthedApi;
+
+const mockDeps = {
+  getAuthApi: () => Promise.resolve(mockAuthedApi),
+};
+
+const tomorrow = new Date(Date.now() + 1000 * 60 * 60 * 24);
+const tomorrowStr = tomorrow.toISOString().split("T")[0];
+
+const baseInput = {
+  type: "study" as const,
+  name: "테스트 모임",
+  capacity: 10,
+  description: "설명입니다.",
+  image: "https://images.unsplash.com/photo-1519389950473-47ba0277781c?w=800",
+  location: "online" as const,
+  date: tomorrowStr,
+  time: "15:00",
+  deadlineDate: tomorrowStr,
+  deadlineTime: "09:00",
+  themeColor: "primary",
+  options: [],
+};
+
+const mockSpaceResult = {
+  id: "20",
+  slug: "20",
+  meetingId: 20,
+  location: "online" as const,
+  themeColor: "primary",
+  status: "ongoing" as const,
+  modules: [],
+  createdAt: new Date(),
+};
+
+describe("updateMoim", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdate.mockResolvedValue({ ok: true, data: { id: 20 } });
+    mockUpdateSpace.mockResolvedValue(mockSpaceResult);
+  });
+
+  it("외부 API 호출 후 SPACE DB를 수정한다", async () => {
+    const result = await updateMoim(
+      {
+        meetingId: 20,
+        data: baseInput,
+      },
+      mockDeps,
+    );
+
+    expect(mockUpdate).toHaveBeenCalledOnce();
+    expect(mockUpdateSpace).toHaveBeenCalledOnce();
+
+    expect(mockUpdate).toHaveBeenCalledWith(20, {
+      name: "테스트 모임",
+      type: "스터디",
+      capacity: 10,
+      description: "설명입니다.",
+      image: "https://images.unsplash.com/photo-1519389950473-47ba0277781c?w=800",
+      region: "online",
+      dateTime: new Date(`${tomorrowStr}T15:00`).toISOString(),
+      registrationEnd: new Date(`${tomorrowStr}T09:00`).toISOString(),
+    });
+
+    expect(mockUpdateSpace).toHaveBeenCalledWith(20, {
+      location: "online",
+      themeColor: "primary",
+      modules: [],
+    });
+
+    expect(result.meeting.id).toBe(20);
+  });
+
+  it("project 타입은 프로젝트로 변환한다", async () => {
+    const input = {
+      ...baseInput,
+      type: "project" as const,
+      location: "offline" as const,
+    };
+
+    await updateMoim(
+      {
+        meetingId: 5,
+        data: input,
+      },
+      mockDeps,
+    );
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({
+        type: "프로젝트",
+        region: "offline",
+      }),
+    );
+
+    expect(mockUpdateSpace).toHaveBeenCalledWith(5, {
+      location: "offline",
+      themeColor: "primary",
+      modules: [],
+    });
+  });
+
+  it("외부 API 실패 시 에러를 던짐", async () => {
+    mockUpdate.mockResolvedValue({ ok: false });
+
+    await expect(
+      updateMoim(
+        {
+          meetingId: 20,
+          data: baseInput,
+        },
+        mockDeps,
+      ),
+    ).rejects.toThrow("모임 수정에 실패했습니다.");
+  });
+
+  it("외부 API 실패 시 SPACE DB update를 호출하지 않는다", async () => {
+    mockUpdate.mockResolvedValue({ ok: false });
+
+    await expect(
+      updateMoim(
+        {
+          meetingId: 20,
+          data: baseInput,
+        },
+        mockDeps,
+      ),
+    ).rejects.toThrow();
+
+    expect(mockUpdateSpace).not.toHaveBeenCalled();
+  });
+
+  it("로그인하지 않은 경우 에러를 던짐", async () => {
+    const { isAuth } = await import("@/shared/api/server");
+    vi.mocked(isAuth).mockResolvedValueOnce({
+      authenticated: false,
+      userId: null,
+    });
+
+    await expect(
+      updateMoim(
+        {
+          meetingId: 20,
+          data: baseInput,
+        },
+        mockDeps,
+      ),
+    ).rejects.toThrow("로그인이 필요합니다.");
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockUpdateSpace).not.toHaveBeenCalled();
+  });
+
+  it("SPACE DB 수정 실패 시 에러를 던짐", async () => {
+    mockUpdateSpace.mockRejectedValue(new Error("Space 저장 결과를 받아오지 못했습니다."));
+
+    await expect(
+      updateMoim(
+        {
+          meetingId: 20,
+          data: baseInput,
+        },
+        mockDeps,
+      ),
+    ).rejects.toThrow("Space 저장 결과를 받아오지 못했습니다.");
+  });
+});

--- a/apps/web/src/_pages/moim-edit/use-cases/moim-update.ts
+++ b/apps/web/src/_pages/moim-edit/use-cases/moim-update.ts
@@ -1,3 +1,4 @@
+import { spaceQueries } from "@/entities/spaces";
 import type { MoimCreateFormValues } from "@/features/moim-create/model/schema";
 import { getApi, isAuth } from "@/shared/api/server";
 
@@ -34,6 +35,12 @@ export async function updateMoim({ meetingId, data }: UpdateMoimParams, { getAut
   if (!res.ok) {
     throw new Error("모임 수정에 실패했습니다.");
   }
+
+  await spaceQueries.updateByMeetingId(meetingId, {
+    location: data.location,
+    themeColor: data.themeColor,
+    modules: data.options ?? [],
+  });
 
   return {
     meeting: res.data,

--- a/apps/web/src/_pages/moim-edit/use-cases/moim-update.ts
+++ b/apps/web/src/_pages/moim-edit/use-cases/moim-update.ts
@@ -1,0 +1,41 @@
+import type { MoimCreateFormValues } from "@/features/moim-create/model/schema";
+import { getApi, isAuth } from "@/shared/api/server";
+
+type UpdateMoimParams = {
+  meetingId: number;
+  data: MoimCreateFormValues;
+};
+
+type Deps = {
+  getAuthApi?: () => ReturnType<typeof getApi>;
+};
+
+export async function updateMoim({ meetingId, data }: UpdateMoimParams, { getAuthApi = getApi }: Deps = {}) {
+  const meetingPayload = {
+    name: data.name,
+    type: data.type === "study" ? "스터디" : "프로젝트",
+    capacity: data.capacity,
+    description: data.description,
+    image: data.image,
+    region: data.location,
+    dateTime: new Date(`${data.date}T${data.time}`).toISOString(),
+    registrationEnd: new Date(`${data.deadlineDate}T${data.deadlineTime}`).toISOString(),
+  };
+
+  const authedApi = await getAuthApi();
+  const { userId } = await isAuth();
+
+  if (userId == null) {
+    throw new Error("로그인이 필요합니다.");
+  }
+
+  const res = await authedApi.meetings.update(meetingId, meetingPayload);
+
+  if (!res.ok) {
+    throw new Error("모임 수정에 실패했습니다.");
+  }
+
+  return {
+    meeting: res.data,
+  };
+}

--- a/apps/web/src/app/(main)/moim-edit/[meetingId]/page.tsx
+++ b/apps/web/src/app/(main)/moim-edit/[meetingId]/page.tsx
@@ -13,6 +13,18 @@ interface MoimEditContentProps {
   meetingId: number;
 }
 
+interface MeetingDetailForEdit {
+  type: string | null;
+  name: string | null;
+  capacity: number | null;
+  description: string | null;
+  image: string | null;
+  region: string | null;
+  dateTime: string | null;
+  registrationEnd: string | null;
+  themeColor?: string | null;
+}
+
 function formatDate(value?: string | null) {
   if (!value) return "";
 
@@ -52,11 +64,11 @@ function formatTime(value?: string | null) {
   return `${hour}:${minute}`;
 }
 
-function mapMeetingDetailToEditFormValues(meetingDetail: any): MoimCreateFormValues {
+function mapMeetingDetailToEditFormValues(meetingDetail: MeetingDetailForEdit): MoimCreateFormValues {
   return {
     type: meetingDetail.type === "프로젝트" ? "project" : "study",
     name: meetingDetail.name ?? "",
-    capacity: meetingDetail.capacity ?? undefined,
+    capacity: Number(meetingDetail.capacity ?? 1),
     description: meetingDetail.description ?? "",
     image: meetingDetail.image ?? "",
     location: meetingDetail.region === "offline" ? "offline" : "online",
@@ -64,7 +76,7 @@ function mapMeetingDetailToEditFormValues(meetingDetail: any): MoimCreateFormVal
     time: formatTime(meetingDetail.dateTime),
     deadlineDate: formatDate(meetingDetail.registrationEnd),
     deadlineTime: formatTime(meetingDetail.registrationEnd),
-    themeColor: "primary",
+    themeColor: meetingDetail.themeColor ?? "primary",
   };
 }
 
@@ -95,7 +107,7 @@ export default async function MoimEditPage({ params }: PageProps) {
   const { meetingId } = await params;
   const numericMeetingId = Number(meetingId);
 
-  if (Number.isNaN(numericMeetingId)) {
+  if (!Number.isInteger(numericMeetingId) || numericMeetingId <= 0) {
     notFound();
   }
 

--- a/apps/web/src/app/(main)/moim-edit/[meetingId]/page.tsx
+++ b/apps/web/src/app/(main)/moim-edit/[meetingId]/page.tsx
@@ -1,0 +1,103 @@
+import { notFound } from "next/navigation";
+import type { MoimCreateFormValues } from "@/features/moim-create/model/schema";
+import { MoimEditForm } from "@/features/moim-edit/ui/moim-edit-form";
+import { getApi } from "@/shared/api/server";
+
+interface PageProps {
+  params: Promise<{
+    meetingId: string;
+  }>;
+}
+
+interface MoimEditContentProps {
+  meetingId: number;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "";
+
+  const date = new Date(value);
+
+  const formatter = new Intl.DateTimeFormat("ko-KR", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  const parts = formatter.formatToParts(date);
+  const year = parts.find((part) => part.type === "year")?.value ?? "";
+  const month = parts.find((part) => part.type === "month")?.value ?? "";
+  const day = parts.find((part) => part.type === "day")?.value ?? "";
+
+  return `${year}-${month}-${day}`;
+}
+
+function formatTime(value?: string | null) {
+  if (!value) return "";
+
+  const date = new Date(value);
+
+  const formatter = new Intl.DateTimeFormat("ko-KR", {
+    timeZone: "Asia/Seoul",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  const parts = formatter.formatToParts(date);
+  const hour = parts.find((part) => part.type === "hour")?.value ?? "";
+  const minute = parts.find((part) => part.type === "minute")?.value ?? "";
+
+  return `${hour}:${minute}`;
+}
+
+function mapMeetingDetailToEditFormValues(meetingDetail: any): MoimCreateFormValues {
+  return {
+    type: meetingDetail.type === "프로젝트" ? "project" : "study",
+    name: meetingDetail.name ?? "",
+    capacity: meetingDetail.capacity ?? undefined,
+    description: meetingDetail.description ?? "",
+    image: meetingDetail.image ?? "",
+    location: meetingDetail.region === "offline" ? "offline" : "online",
+    date: formatDate(meetingDetail.dateTime),
+    time: formatTime(meetingDetail.dateTime),
+    deadlineDate: formatDate(meetingDetail.registrationEnd),
+    deadlineTime: formatTime(meetingDetail.registrationEnd),
+    themeColor: "primary",
+  };
+}
+
+async function MoimEditContent({ meetingId }: MoimEditContentProps) {
+  const apiClient = await getApi();
+
+  try {
+    const meetingDetailResponse = await apiClient.meetings.getDetail(meetingId);
+    const meetingDetail = "data" in meetingDetailResponse ? meetingDetailResponse.data : meetingDetailResponse;
+
+    if (!meetingDetail) {
+      return <div>모임 정보를 표시할 수 없습니다.</div>;
+    }
+
+    const initialValues = mapMeetingDetailToEditFormValues(meetingDetail);
+
+    return (
+      <div className="mx-auto w-full max-w-[1120px] px-5 py-6 md:px-6 md:py-10 xl:px-10">
+        <MoimEditForm meetingId={meetingId} initialValues={initialValues} />
+      </div>
+    );
+  } catch {
+    return <div>모임 정보를 표시할 수 없습니다.</div>;
+  }
+}
+
+export default async function MoimEditPage({ params }: PageProps) {
+  const { meetingId } = await params;
+  const numericMeetingId = Number(meetingId);
+
+  if (Number.isNaN(numericMeetingId)) {
+    notFound();
+  }
+
+  return <MoimEditContent meetingId={numericMeetingId} />;
+}

--- a/apps/web/src/entities/spaces/queries.ts
+++ b/apps/web/src/entities/spaces/queries.ts
@@ -17,4 +17,13 @@ export const spaceQueries = {
     }
     return result;
   },
+  updateByMeetingId: async (meetingId: number, data: Partial<NewSpaceDB>) => {
+    const [result] = await db.update(spaces).set(data).where(eq(spaces.meetingId, meetingId)).returning();
+
+    if (!result) {
+      throw new Error("Space 저장 결과를 받아오지 못했습니다.");
+    }
+
+    return result;
+  },
 };

--- a/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
+++ b/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { Button, CategoryTab, FileInput, InputField, InputTextArea } from "@ui/components";
+import { RadioGroup, RadioGroupItem } from "@ui/components/shadcn/radio-group";
+import Image from "next/image";
+import type { BaseSyntheticEvent } from "react";
+import { Controller, type UseFormReturn } from "react-hook-form";
+import { DatePicker, icoProject, icoStudy, TimePicker } from "@/_pages/moim-create";
+import { ThemeColorSelect } from "@/features/moim-create/ui/theme-color-select";
+
+export interface MoimFormValues {
+  type: "study" | "project";
+  name: string;
+  capacity: number;
+  location: "online" | "offline";
+  description: string;
+  image: string;
+  date: string;
+  time: string;
+  deadlineDate: string;
+  deadlineTime: string;
+  themeColor: string;
+}
+
+interface MoimFormState {
+  ok: boolean;
+  error?: string;
+}
+
+interface MoimFormFieldsProps {
+  form: UseFormReturn<MoimFormValues>;
+  onSubmit: (event?: BaseSyntheticEvent) => void | Promise<void>;
+  state: MoimFormState | null;
+  isPending: boolean;
+  submitLabel: string;
+  onCancel: () => void;
+  onImageUpload: (onChange: (url: string) => void) => Promise<void>;
+}
+
+export const MoimFormFields = ({
+  form,
+  onSubmit,
+  state,
+  isPending,
+  submitLabel,
+  onCancel,
+  onImageUpload,
+}: MoimFormFieldsProps) => {
+  const {
+    control,
+    register,
+    clearErrors,
+    formState: { errors },
+  } = form;
+
+  return (
+    <form className="flex flex-col gap-6 rounded-[40px] bg-white p-8 md:p-[48px]" onSubmit={onSubmit}>
+      <h3 className="font-semibold text-foreground text-xl md:text-2xl">모임</h3>
+
+      <div className="flex flex-col justify-between md:flex-row md:gap-[56px]">
+        <div className="flex-1 space-y-6">
+          <Controller
+            control={control}
+            name="type"
+            render={({ field, fieldState }) => (
+              <div>
+                <p className="pb-2 font-semibold text-foreground text-sm leading-[1.2]">
+                  이 모임은 어떤 종류인가요?
+                  <span className="pl-1 text-primary">*</span>
+                </p>
+
+                <div className="flex gap-5">
+                  <CategoryTab
+                    illustration={<Image src={icoStudy} alt="" />}
+                    label="스터디"
+                    selected={field.value === "study"}
+                    onClick={() => field.onChange("study")}
+                  />
+                  <CategoryTab
+                    illustration={<Image src={icoProject} alt="" />}
+                    label="프로젝트"
+                    selected={field.value === "project"}
+                    onClick={() => field.onChange("project")}
+                  />
+                </div>
+
+                {fieldState.error && (
+                  <p className="pt-2 font-medium text-destructive text-sm leading-[1.2]">{fieldState.error.message}</p>
+                )}
+              </div>
+            )}
+          />
+
+          <InputField
+            label="모임 이름"
+            placeholder="모임 이름을 입력해주세요"
+            required
+            isDestructive={!!errors.name}
+            message={errors.name?.message}
+            {...register("name")}
+          />
+
+          <InputField
+            label="모임 정원"
+            placeholder="숫자만 입력해주세요"
+            type="number"
+            required
+            min={1}
+            max={1000}
+            isDestructive={!!errors.capacity}
+            message={errors.capacity?.message}
+            {...register("capacity", { valueAsNumber: true })}
+            onKeyDown={(event) => {
+              if (["-", "e", "E", "+"].includes(event.key)) {
+                event.preventDefault();
+              }
+            }}
+          />
+
+          <Controller
+            control={control}
+            name="location"
+            render={({ field, fieldState }) => (
+              <RadioGroup value={field.value} onValueChange={field.onChange}>
+                <p className="font-semibold text-foreground text-sm leading-[1.2]">
+                  장소<span className="pl-1 text-primary">*</span>
+                </p>
+
+                <div className="flex gap-10">
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="online" id="online" />
+                    <label htmlFor="online">온라인</label>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="offline" id="offline" />
+                    <label htmlFor="offline">오프라인</label>
+                  </div>
+                </div>
+
+                {fieldState.error && (
+                  <p className="font-medium text-destructive text-sm leading-[1.2]">{fieldState.error.message}</p>
+                )}
+              </RadioGroup>
+            )}
+          />
+        </div>
+
+        <div className="mt-6 flex-1 space-y-6 md:mt-0">
+          <InputTextArea
+            label="모임 설명"
+            placeholder="모임을 설명해주세요"
+            required
+            isDestructive={!!errors.description}
+            message={errors.description?.message}
+            {...register("description")}
+          />
+
+          <Controller
+            control={control}
+            name="image"
+            render={({ field, fieldState }) => (
+              <div className="flex flex-col gap-2">
+                <p className="font-semibold text-foreground text-sm leading-[1.2]">
+                  이미지<span className="pl-1 text-primary">*</span>
+                </p>
+
+                <FileInput
+                  onUploadClick={() => onImageUpload(field.onChange)}
+                  previewItems={field.value ? [{ id: "1", imageUrl: field.value }] : []}
+                  onPreviewRemove={() => {
+                    field.onChange("");
+                    clearErrors("image");
+                  }}
+                  showUploadButton={!field.value}
+                />
+
+                {fieldState.error && (
+                  <p className="font-medium text-destructive text-sm leading-[1.2]">{fieldState.error.message}</p>
+                )}
+              </div>
+            )}
+          />
+
+          <div>
+            <p className="pb-2 font-semibold text-foreground text-sm leading-[1.2]">
+              모임 일정<span className="pl-1 text-primary">*</span>
+            </p>
+
+            <div className="flex max-w-[456px] flex-col gap-4 md:flex-row">
+              <Controller
+                control={control}
+                name="date"
+                render={({ field, fieldState }) => (
+                  <div className="flex flex-1 flex-col gap-2">
+                    <DatePicker value={field.value} onChange={field.onChange} />
+                    {fieldState.error && (
+                      <p className="font-medium text-destructive text-sm leading-[1.2]">{fieldState.error.message}</p>
+                    )}
+                  </div>
+                )}
+              />
+
+              <Controller
+                control={control}
+                name="time"
+                render={({ field, fieldState }) => (
+                  <div className="flex flex-1 flex-col gap-2">
+                    <TimePicker value={field.value} onChange={field.onChange} />
+                    {fieldState.error && (
+                      <p className="font-medium text-destructive text-sm leading-[1.2]">{fieldState.error.message}</p>
+                    )}
+                  </div>
+                )}
+              />
+            </div>
+          </div>
+
+          <div>
+            <p className="pb-2 font-semibold text-foreground text-sm leading-[1.2]">
+              모집 마감 날짜<span className="pl-1 text-primary">*</span>
+            </p>
+
+            <div className="flex max-w-[456px] flex-col gap-4 md:flex-row">
+              <Controller
+                control={control}
+                name="deadlineDate"
+                render={({ field, fieldState }) => (
+                  <div className="flex flex-1 flex-col gap-2">
+                    <DatePicker value={field.value} onChange={field.onChange} />
+                    {fieldState.error && (
+                      <p className="font-medium text-destructive text-sm leading-[1.2]">{fieldState.error.message}</p>
+                    )}
+                  </div>
+                )}
+              />
+
+              <Controller
+                control={control}
+                name="deadlineTime"
+                render={({ field, fieldState }) => (
+                  <div className="flex flex-1 flex-col gap-2">
+                    <TimePicker value={field.value} onChange={field.onChange} />
+                    {fieldState.error && (
+                      <p className="font-medium text-destructive text-sm leading-[1.2]">{fieldState.error.message}</p>
+                    )}
+                  </div>
+                )}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <h3 className="font-semibold text-foreground text-xl md:text-2xl">스페이스</h3>
+
+      <div className="flex flex-col justify-between gap-[56px] md:flex-row">
+        <div className="max-w-[456px] flex-1">
+          <Controller
+            control={control}
+            name="themeColor"
+            render={({ field, fieldState }) => (
+              <div className="flex flex-col gap-2">
+                <p className="font-semibold text-foreground text-sm leading-[1.2]">
+                  테마<span className="pl-1 text-primary">*</span>
+                </p>
+
+                <ThemeColorSelect value={field.value} onValueChange={field.onChange} />
+
+                {fieldState.error && (
+                  <p className="font-medium text-destructive text-sm leading-[1.2]">{fieldState.error.message}</p>
+                )}
+              </div>
+            )}
+          />
+        </div>
+
+        <div className="flex-1" />
+      </div>
+
+      {state && !state.ok && <p className="font-medium text-destructive text-sm">{state.error}</p>}
+
+      <div className="flex gap-4 pt-[80px] md:justify-end">
+        <Button
+          type="button"
+          variant="tertiary"
+          size="medium"
+          className="min-w-0 flex-1 md:max-w-[216px]"
+          onClick={onCancel}
+        >
+          취소
+        </Button>
+
+        <Button
+          type="submit"
+          variant="primary"
+          size="medium"
+          className="min-w-0 flex-1 md:w-auto md:max-w-[216px]"
+          disabled={isPending}
+        >
+          {submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+};

--- a/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
+++ b/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
@@ -6,21 +6,8 @@ import Image from "next/image";
 import type { BaseSyntheticEvent } from "react";
 import { Controller, type UseFormReturn } from "react-hook-form";
 import { DatePicker, icoProject, icoStudy, TimePicker } from "@/_pages/moim-create";
+import type { MoimCreateFormValues } from "@/features/moim-create/model/schema";
 import { ThemeColorSelect } from "@/features/moim-create/ui/theme-color-select";
-
-export interface MoimFormValues {
-  type: "study" | "project";
-  name: string;
-  capacity: number;
-  location: "online" | "offline";
-  description: string;
-  image: string;
-  date: string;
-  time: string;
-  deadlineDate: string;
-  deadlineTime: string;
-  themeColor: string;
-}
 
 interface MoimFormState {
   ok: false;
@@ -28,8 +15,8 @@ interface MoimFormState {
 }
 
 interface MoimFormFieldsProps {
-  form: UseFormReturn<MoimFormValues>;
-  onSubmit: (event?: BaseSyntheticEvent) => void | Promise<void>;
+  form: UseFormReturn<MoimCreateFormValues>;
+  onSubmit: (event?: React.BaseSyntheticEvent) => void;
   state: MoimFormState | null;
   isPending: boolean;
   submitLabel: string;

--- a/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
+++ b/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
@@ -265,7 +265,7 @@ export const MoimFormFields = ({
         <div className="flex-1" />
       </div>
 
-      {state && !state.ok && <p className="font-medium text-destructive text-sm">{state.error}</p>}
+      {state?.error && <p className="font-medium text-destructive text-sm">{state.error}</p>}
 
       <div className="flex gap-4 pt-[80px] md:justify-end">
         <Button

--- a/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
+++ b/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
@@ -23,7 +23,7 @@ export interface MoimFormValues {
 }
 
 interface MoimFormState {
-  ok: boolean;
+  ok: false;
   error?: string;
 }
 

--- a/apps/web/src/features/moim-edit/model/use-moim-edit-form.ts
+++ b/apps/web/src/features/moim-edit/model/use-moim-edit-form.ts
@@ -31,14 +31,16 @@ export const useMoimEditForm = ({ meetingId, initialValues }: UseMoimEditFormPar
   const [state, formAction, isPending] = useActionState(updateMoimAction, null);
 
   const form = useForm<MoimCreateFormValues>({
-    resolver: zodResolver(moimCreateSchema as any),
+    resolver: zodResolver(moimCreateSchema),
     defaultValues: initialValues,
     mode: "onSubmit",
   });
 
+  const { reset } = form;
+
   useEffect(() => {
-    form.reset(initialValues);
-  }, [initialValues, form]);
+    reset(initialValues);
+  }, [initialValues, reset]);
 
   const onSubmit = form.handleSubmit((data) => {
     startTransition(() => {

--- a/apps/web/src/features/moim-edit/model/use-moim-edit-form.ts
+++ b/apps/web/src/features/moim-edit/model/use-moim-edit-form.ts
@@ -1,0 +1,50 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { startTransition, useActionState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { updateMoimAction } from "@/_pages/moim-edit/actions";
+import { type MoimCreateFormValues, moimCreateSchema } from "@/features/moim-create/model/schema";
+
+interface UseMoimEditFormParams {
+  meetingId: number;
+  initialValues: MoimCreateFormValues;
+}
+
+const objectToFormData = (meetingId: number, data: MoimCreateFormValues): FormData => {
+  const formData = new FormData();
+
+  formData.append("meetingId", String(meetingId));
+
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        formData.append(key, String(item));
+      }
+    } else {
+      formData.append(key, String(value ?? ""));
+    }
+  }
+
+  return formData;
+};
+
+export const useMoimEditForm = ({ meetingId, initialValues }: UseMoimEditFormParams) => {
+  const [state, formAction, isPending] = useActionState(updateMoimAction, null);
+
+  const form = useForm<MoimCreateFormValues>({
+    resolver: zodResolver(moimCreateSchema as any),
+    defaultValues: initialValues,
+    mode: "onSubmit",
+  });
+
+  useEffect(() => {
+    form.reset(initialValues);
+  }, [initialValues, form]);
+
+  const onSubmit = form.handleSubmit((data) => {
+    startTransition(() => {
+      formAction(objectToFormData(meetingId, data));
+    });
+  });
+
+  return { form, onSubmit, state, isPending };
+};

--- a/apps/web/src/features/moim-edit/ui/moim-edit-form.tsx
+++ b/apps/web/src/features/moim-edit/ui/moim-edit-form.tsx
@@ -2,12 +2,13 @@
 
 import { useRouter } from "next/navigation";
 import { uploadImage } from "@/_pages/moim-create/use-cases/upload-image";
-import { MoimFormFields, type MoimFormValues } from "@/features/moim-create/ui/moim-form-fields";
+import type { MoimCreateFormValues } from "@/features/moim-create/model/schema";
+import { MoimFormFields } from "@/features/moim-create/ui/moim-form-fields";
 import { useMoimEditForm } from "@/features/moim-edit/model/use-moim-edit-form";
 
 interface MoimEditFormProps {
   meetingId: number;
-  initialValues: MoimFormValues;
+  initialValues: MoimCreateFormValues;
 }
 
 export const MoimEditForm = ({ meetingId, initialValues }: MoimEditFormProps) => {

--- a/apps/web/src/features/moim-edit/ui/moim-edit-form.tsx
+++ b/apps/web/src/features/moim-edit/ui/moim-edit-form.tsx
@@ -2,12 +2,21 @@
 
 import { useRouter } from "next/navigation";
 import { uploadImage } from "@/_pages/moim-create/use-cases/upload-image";
-import { useMoimCreateForm } from "@/features/moim-create/model/use-moim-create-form";
-import { MoimFormFields } from "@/features/moim-create/ui/moim-form-fields";
+import { MoimFormFields, type MoimFormValues } from "@/features/moim-create/ui/moim-form-fields";
+import { useMoimEditForm } from "@/features/moim-edit/model/use-moim-edit-form";
 
-export const MoimCreateForm = () => {
+interface MoimEditFormProps {
+  meetingId: number;
+  initialValues: MoimFormValues;
+}
+
+export const MoimEditForm = ({ meetingId, initialValues }: MoimEditFormProps) => {
   const router = useRouter();
-  const { form, onSubmit, state, isPending } = useMoimCreateForm();
+  const { form, onSubmit, state, isPending } = useMoimEditForm({
+    meetingId,
+    initialValues,
+  });
+
   const { setError, clearErrors } = form;
 
   const handleImageUpload = async (onChange: (url: string) => void) => {
@@ -40,7 +49,7 @@ export const MoimCreateForm = () => {
       onSubmit={onSubmit}
       state={state}
       isPending={isPending}
-      submitLabel={isPending ? "생성 중" : "모임 만들기"}
+      submitLabel={isPending ? "수정 중" : "수정하기"}
       onCancel={() => router.back()}
       onImageUpload={handleImageUpload}
     />

--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -84,7 +84,10 @@ function createAuthFetch(
 
     const { accessToken: newAccessToken, refreshToken: newRefreshToken } = await refreshResponse.json();
 
-    onTokenRefreshed({ accessToken: newAccessToken, refreshToken: newRefreshToken });
+    onTokenRefreshed({
+      accessToken: newAccessToken,
+      refreshToken: newRefreshToken,
+    });
 
     const retryHeaders = new Headers(init?.headers);
     retryHeaders.set("Authorization", `Bearer ${newAccessToken}`);
@@ -154,8 +157,13 @@ function buildApiShape(core: {
         core.meetings.joinDelete(teamId, meetingId, params),
       delete: (meetingId: number, params?: Parameters<typeof core.meetings.meetingsDelete>[2]) =>
         core.meetings.meetingsDelete(teamId, meetingId, params),
+      update: (
+        meetingId: Parameters<typeof core.meetings.meetingsPartialUpdate>[1],
+        data: Parameters<typeof core.meetings.meetingsPartialUpdate>[2],
+        params?: Parameters<typeof core.meetings.meetingsPartialUpdate>[3],
+      ) => core.meetings.meetingsPartialUpdate(teamId, meetingId, data, params),
 
-      // getList 추가가
+      // getList 추가
       participants: {
         getList: (
           meetingId: Parameters<typeof core.meetings.participantsList>[1],

--- a/apps/web/src/shared/config/routes.ts
+++ b/apps/web/src/shared/config/routes.ts
@@ -3,6 +3,7 @@ export const ROUTES = {
   search: "/search",
   moimCreate: "/moim-create",
   moimDetail: "/moim-detail",
+  moimEdit: "/moim-edit",
   spaces: "/spaces",
   login: "/login",
   signup: "/signup",


### PR DESCRIPTION
## 📌 Summary
모임 수정하기 기능 구현했습니다.

- close #89 

## 📄 Tasks

### 1. 기능 구현
- 모임 수정 페이지(`/moim-edit/[meetingId]`) 생성
- 기존 모임 생성 폼 UI를 공통 컴포넌트(`moim-form-fields.tsx`)로 분리 후 재사용하였습니다.
- `MoimEditForm` 및 `useMoimEditForm` 훅 추가
  - 기존 데이터를 form의 `defaultValues`로 주입
  - 수정 페이지 진입 시 기존 모임 정보가 자동으로 채워지도록 처리

### 2. API / 서버 로직
- `updateMoimAction` Server Action 구현
  - FormData → parse → 검증 → use-case 호출 → redirect 흐름 구성
- `updateMoim` use-case 구현
  - 외부 `meetings.update` API 호출 로직 추가
  - 모임 수정 성공 후 SPACE DB 동기화 로직 추가
  - `spaceQueries.updateByMeetingId` 호출하여 location, themeColor, modules 값 업데이트
  - 테스트 코드(`moim-update.test.ts`) 추가
- `entities/spaces/queries.ts`
  - `updateByMeetingId` 메서드 추가
  - meetingId 기준으로 SPACE 레코드 업데이트 처리

### 3. 상태 및 UX
- 수정 완료 후 모임 상세 페이지로 redirect 처리
- 상세 페이지 모달에서 수정하기 클릭 시 수정 페이지로 이동하도록 라우팅 연결

## 👀 To Reviewer
- 팀 컨벤션과 다르거나 안 되는 케이스가 있다면 말씀 부탁드립니다!

## 📸 Screenshot
https://github.com/user-attachments/assets/bffa73b6-5d94-4238-8162-7f264b5bc0d4

### SPACES DB에도 수정한 값 반영되는 것 확인
<img width="1582" height="975" alt="스크린샷 2026-03-31 오후 2 16 25" src="https://github.com/user-attachments/assets/6f4b35bd-a69d-4f3d-a443-26a4a31307c3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 모임을 편집할 수 있는 모임 수정 페이지 및 편집 UI 추가
  * 편집 완료 후 모임 상세로 자동 이동(리디렉션)

* **개선**
  * 생성/편집 폼 필드 컴포넌트로 분리하여 재사용성 향상 및 입력 검증 강화
  * 이미지 업로드 미리보기 및 편집 중 업로드 처리 개선
  * 클라이언트 API에 모임 업데이트 엔드포인트 추가

* **테스트**
  * 모임 수정 흐름에 대한 단위 테스트 추가 (성공/실패/인증 시나리오)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->