### PR TITLE
[refactor] 랜딩 페이지 인터랙션 개선

### DIFF
--- a/apps/web/src/_pages/landing/index.ts
+++ b/apps/web/src/_pages/landing/index.ts
@@ -1,5 +1,5 @@
 export * from "./assets";
 export { CATEGORIES } from "./constants";
 export { CategoryCard } from "./ui/category-card";
-export { IcoChevronDownDouble } from "./ui/ico-chevron-down-double";
 export { LandingCtaButton } from "./ui/landing-cta-button";
+export { LandingScrollButton } from "./ui/landing-scroll-button";

--- a/apps/web/src/_pages/landing/index.ts
+++ b/apps/web/src/_pages/landing/index.ts
@@ -1,5 +1,6 @@
 export * from "./assets";
 export { CATEGORIES } from "./constants";
 export { CategoryCard } from "./ui/category-card";
+export { LandingCategoryGrid } from "./ui/landing-category-grid";
 export { LandingCtaButton } from "./ui/landing-cta-button";
 export { LandingScrollButton } from "./ui/landing-scroll-button";

--- a/apps/web/src/_pages/landing/ui/landing-category-grid.tsx
+++ b/apps/web/src/_pages/landing/ui/landing-category-grid.tsx
@@ -40,7 +40,7 @@ export function LandingCategoryGrid() {
         <li
           key={category.label}
           className={cn(
-            "lg:transition-[opacity,transform] lg:duration-900 lg:ease-out lg:odd:mt-10",
+            "lg:transition-[opacity,transform] lg:duration-700 lg:ease-out lg:odd:mt-10",
             shown ? "lg:translate-y-0 lg:opacity-100" : "lg:translate-y-6 lg:opacity-0",
           )}
         >

--- a/apps/web/src/_pages/landing/ui/landing-category-grid.tsx
+++ b/apps/web/src/_pages/landing/ui/landing-category-grid.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { cn } from "@ui/lib/utils";
+import { useEffect, useRef, useState } from "react";
+import { CATEGORIES } from "@/_pages/landing/constants";
+import { CategoryCard } from "@/_pages/landing/ui/category-card";
+
+export function LandingCategoryGrid() {
+  const containerRef = useRef<HTMLUListElement | null>(null);
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+
+        setShown(true);
+        observer.unobserve(entry.target);
+      },
+      {
+        threshold: 0.15,
+        rootMargin: "0px 0px -10% 0px",
+      },
+    );
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <ul
+      ref={containerRef}
+      className="mt-12 grid grid-cols-2 gap-4 md:mt-20 md:grid-cols-3 lg:mt-[94px] lg:grid-cols-6 lg:gap-6"
+    >
+      {CATEGORIES.map((category) => (
+        <li
+          key={category.label}
+          className={cn(
+            "lg:transition-[opacity,transform] lg:duration-900 lg:ease-out lg:odd:mt-10",
+            shown ? "lg:translate-y-0 lg:opacity-100" : "lg:translate-y-6 lg:opacity-0",
+          )}
+        >
+          <CategoryCard category={category} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/_pages/landing/ui/landing-scroll-button.tsx
+++ b/apps/web/src/_pages/landing/ui/landing-scroll-button.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { IcoChevronDownDouble } from "@/_pages/landing/ui/ico-chevron-down-double";
+
+export const LandingScrollButton = () => (
+  <button
+    type="button"
+    aria-label="다음 섹션으로 이동"
+    className="mx-auto mt-auto mb-6 animate-bounce motion-reduce:animate-none lg:mb-10"
+    onClick={() =>
+      document.getElementById("landing-find")?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      })
+    }
+  >
+    <IcoChevronDownDouble />
+  </button>
+);

--- a/apps/web/src/_pages/landing/ui/landing-scroll-button.tsx
+++ b/apps/web/src/_pages/landing/ui/landing-scroll-button.tsx
@@ -7,12 +7,13 @@ export const LandingScrollButton = () => (
     type="button"
     aria-label="다음 섹션으로 이동"
     className="mx-auto mt-auto mb-6 animate-bounce motion-reduce:animate-none lg:mb-10"
-    onClick={() =>
+    onClick={() => {
+      const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
       document.getElementById("landing-find")?.scrollIntoView({
-        behavior: "smooth",
+        behavior: reduceMotion ? "auto" : "smooth",
         block: "start",
-      })
-    }
+      });
+    }}
   >
     <IcoChevronDownDouble />
   </button>

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -3,9 +3,8 @@ import {
   bgDoubleOval,
   bgEllipse,
   bgStar,
-  CATEGORIES,
-  CategoryCard,
   heroImage,
+  LandingCategoryGrid,
   LandingCtaButton,
   LandingScrollButton,
   spaceLg,
@@ -56,11 +55,7 @@ export default function Home() {
             취향에 따라서 원하는 모임을 골라보세요.
           </p>
         </div>
-        <div className="mt-12 grid grid-cols-2 gap-4 md:mt-20 md:grid-cols-3 lg:mt-[94px] lg:grid-cols-6 lg:gap-6">
-          {CATEGORIES.map((category) => (
-            <CategoryCard key={category.label} category={category} />
-          ))}
-        </div>
+        <LandingCategoryGrid />
       </section>
 
       <section className="overflow-hidden bg-gray-100 px-5 py-[64px] md:px-8 md:pt-[80px] md:pb-[120px] lg:px-[72px] lg:pt-[110px] lg:pb-[180px]">

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -6,8 +6,8 @@ import {
   CATEGORIES,
   CategoryCard,
   heroImage,
-  IcoChevronDownDouble,
   LandingCtaButton,
+  LandingScrollButton,
   spaceLg,
   spaceMd,
   spaceSm,
@@ -40,12 +40,13 @@ export default function Home() {
             className="w-[90vw] object-contain md:absolute md:top-[80%] md:-right-[24px] md:w-[50vw] lg:top-[60%] lg:right-[-10%] xl:top-[138px] xl:-right-[16%] xl:w-[58vw] xl:max-w-[800px]"
           />
         </div>
-        <button type="button" aria-label="아래로 이동" className="mx-auto mt-auto mb-6 lg:mb-10">
-          <IcoChevronDownDouble />
-        </button>
+        <LandingScrollButton />
       </section>
 
-      <section className="px-5 py-[64px] md:px-8 md:pt-[80px] md:pb-[120px] lg:px-[72px] lg:pt-[110px] lg:pb-[180px]">
+      <section
+        id="landing-find"
+        className="px-5 py-[64px] md:px-8 md:pt-[80px] md:pb-[120px] lg:px-[72px] lg:pt-[110px] lg:pb-[180px]"
+      >
         <div className="flex flex-col items-center justify-center gap-1 lg:gap-2">
           <p className="pb-2 font-semibold text-green-600 text-sm md:text-xl lg:pb-4">모임 찾기</p>
           <h3 className="font-bold text-foreground text-xl leading-[30px] tracking-tight md:text-[40px] md:leading-[56px]">


### PR DESCRIPTION
## 📌 Summary

랜딩 페이지 hero 하단 스크롤 인터렉션 및 카드 진입 애니메이션을 구현했습니다.

- close #97

## 📄 Tasks

- LandingScrollButton 추가  
  - hero 하단 버튼 클릭 시 모임찾기 섹션으로 smooth scroll 이동
- LandingCategoryGrid 컴포넌트 분리  
  - IntersectionObserver 기반 진입 감지
  - fade-in + translate 애니메이션 적용
  - md 이하 구간에서는 카드가 밀집되어 있어 애니메이션 효과가 잘 드러나지 않아 lg 이상에만 적용했습니다.

## 👀 To Reviewer

- 현재 IntersectionObserver 로직은 랜딩 페이지에서만 사용되고 있어 컴포넌트 내부에 유지했습니다.  추후 동일한 패턴이 반복될 경우 공용 훅으로 분리할 예정입니다.


## 📸 Screenshot

- 카드 애니메이션 적용 전

https://github.com/user-attachments/assets/b9f363f0-408c-4eca-90db-3eff147e6623

- LandingScrollButton 및 카드 애니메이션 적용 

https://github.com/user-attachments/assets/480fa918-908d-4b4c-aa31-adbb8dfe790c




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 랜딩 페이지에 카테고리 그리드 컴포넌트를 추가하여 항목이 스크롤 시 애니메틱하게 노출됩니다.
  * 영웅 섹션의 스크롤 버튼을 개선해 부드러운 스크롤 이동을 제공합니다.
  * 접근성 고려: 버튼에 레이블을 추가하고 사용자의 '감소된 모션' 설정을 존중하도록 애니메이션을 비활성화합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->