### PR TITLE
[feat] 스페이스 내부 프로필 수정 액션, 유스케이스 구현

### DIFF
--- a/apps/web/src/_pages/space/actions.ts
+++ b/apps/web/src/_pages/space/actions.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { revalidatePath, revalidateTag } from "next/cache";
+import type { Member } from "@/entities/member";
+import { getSpaceContext } from "@/features/space/lib/get-space-context";
+import { updateMemberProfileUseCase } from "./use-cases/update-member-profile";
+
+export interface UpdateMemberProfileActionInput {
+  avatarUrl?: string | null;
+  email?: string | null;
+  nickname: string;
+}
+
+export async function updateMemberProfileAction(
+  slug: string,
+  input: UpdateMemberProfileActionInput,
+): Promise<{ member: Member }> {
+  const { space, membership } = await getSpaceContext(slug);
+
+  const member = await updateMemberProfileUseCase({
+    avatarUrl: input.avatarUrl,
+    email: input.email,
+    nickname: input.nickname,
+    spaceId: space.spaceId,
+    userId: membership.userId,
+  });
+
+  revalidateTag(`membership-${space.spaceId}`, "max");
+  revalidateTag(`members-${space.spaceId}`, "max");
+  revalidatePath(`/${slug}`);
+
+  return { member };
+}

--- a/apps/web/src/_pages/space/actions.ts
+++ b/apps/web/src/_pages/space/actions.ts
@@ -8,7 +8,7 @@ import { updateMemberProfileUseCase } from "./use-cases/update-member-profile";
 export interface UpdateMemberProfileActionInput {
   avatarUrl?: string | null;
   email?: string | null;
-  nickname: string;
+  nickname?: string;
 }
 
 export async function updateMemberProfileAction(

--- a/apps/web/src/_pages/space/use-cases/update-member-profile.test.ts
+++ b/apps/web/src/_pages/space/use-cases/update-member-profile.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/entities/member", () => ({
+  memberQueries: {
+    update: vi.fn(),
+  },
+}));
+
+import { memberQueries } from "@/entities/member";
+import { updateMemberProfileUseCase } from "./update-member-profile";
+
+const mockUpdate = vi.mocked(memberQueries.update);
+
+const BASE_MEMBER = {
+  avatarUrl: null,
+  email: null,
+  id: "member-1",
+  joinedAt: "2026-03-31T00:00:00.000Z",
+  nickname: "기존 닉네임",
+  role: "member" as const,
+  spaceId: "space-1",
+  userId: 7,
+};
+
+describe("updateMemberProfileUseCase", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdate.mockResolvedValue(BASE_MEMBER);
+  });
+
+  it("정규화한 프로필 값으로 memberQueries.update를 호출한다", async () => {
+    const result = await updateMemberProfileUseCase({
+      avatarUrl: "  https://example.com/avatar.png  ",
+      email: "  user@example.com  ",
+      nickname: "  새 닉네임  ",
+      spaceId: "space-1",
+      userId: 7,
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith("space-1", 7, {
+      avatarUrl: "https://example.com/avatar.png",
+      email: "user@example.com",
+      nickname: "새 닉네임",
+    });
+    expect(result).toEqual(BASE_MEMBER);
+  });
+
+  it("빈 이메일과 아바타 URL은 null로 정규화한다", async () => {
+    await updateMemberProfileUseCase({
+      avatarUrl: "   ",
+      email: "",
+      nickname: "닉네임",
+      spaceId: "space-1",
+      userId: 7,
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith("space-1", 7, {
+      avatarUrl: null,
+      email: null,
+      nickname: "닉네임",
+    });
+  });
+
+  it("닉네임이 비어 있으면 에러를 던진다", async () => {
+    await expect(
+      updateMemberProfileUseCase({
+        nickname: "   ",
+        spaceId: "space-1",
+        userId: 7,
+      }),
+    ).rejects.toThrow("닉네임을 입력해주세요.");
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("닉네임이 20자를 초과하면 에러를 던진다", async () => {
+    await expect(
+      updateMemberProfileUseCase({
+        nickname: "123456789012345678901",
+        spaceId: "space-1",
+        userId: 7,
+      }),
+    ).rejects.toThrow("닉네임은 20자 이하로 입력해주세요.");
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("업데이트할 멤버가 없으면 에러를 던진다", async () => {
+    mockUpdate.mockResolvedValue(undefined as never);
+
+    await expect(
+      updateMemberProfileUseCase({
+        nickname: "닉네임",
+        spaceId: "space-1",
+        userId: 7,
+      }),
+    ).rejects.toThrow("멤버 정보를 찾을 수 없습니다.");
+  });
+});

--- a/apps/web/src/_pages/space/use-cases/update-member-profile.test.ts
+++ b/apps/web/src/_pages/space/use-cases/update-member-profile.test.ts
@@ -28,7 +28,7 @@ describe("updateMemberProfileUseCase", () => {
     mockUpdate.mockResolvedValue(BASE_MEMBER);
   });
 
-  it("정규화한 프로필 값으로 memberQueries.update를 호출한다", async () => {
+  it("전달된 필드를 정규화한 뒤 수정한다", async () => {
     const result = await updateMemberProfileUseCase({
       avatarUrl: "  https://example.com/avatar.png  ",
       email: "  user@example.com  ",
@@ -45,11 +45,46 @@ describe("updateMemberProfileUseCase", () => {
     expect(result).toEqual(BASE_MEMBER);
   });
 
-  it("빈 이메일과 아바타 URL은 null로 정규화한다", async () => {
+  it("닉네임만 전달되면 닉네임만 수정한다", async () => {
+    await updateMemberProfileUseCase({
+      nickname: "새 닉네임",
+      spaceId: "space-1",
+      userId: 7,
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith("space-1", 7, {
+      nickname: "새 닉네임",
+    });
+  });
+
+  it("이메일만 전달되면 이메일만 수정한다", async () => {
+    await updateMemberProfileUseCase({
+      email: "  user@example.com  ",
+      spaceId: "space-1",
+      userId: 7,
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith("space-1", 7, {
+      email: "user@example.com",
+    });
+  });
+
+  it("아바타 URL만 전달되면 아바타 URL만 수정한다", async () => {
+    await updateMemberProfileUseCase({
+      avatarUrl: "  https://example.com/avatar.png  ",
+      spaceId: "space-1",
+      userId: 7,
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith("space-1", 7, {
+      avatarUrl: "https://example.com/avatar.png",
+    });
+  });
+
+  it("이메일과 아바타 URL을 빈 값으로 보내면 null로 정규화한다", async () => {
     await updateMemberProfileUseCase({
       avatarUrl: "   ",
       email: "",
-      nickname: "닉네임",
       spaceId: "space-1",
       userId: 7,
     });
@@ -57,11 +92,10 @@ describe("updateMemberProfileUseCase", () => {
     expect(mockUpdate).toHaveBeenCalledWith("space-1", 7, {
       avatarUrl: null,
       email: null,
-      nickname: "닉네임",
     });
   });
 
-  it("닉네임이 비어 있으면 에러를 던진다", async () => {
+  it("닉네임이 전달됐지만 비어 있으면 에러를 던진다", async () => {
     await expect(
       updateMemberProfileUseCase({
         nickname: "   ",
@@ -85,12 +119,23 @@ describe("updateMemberProfileUseCase", () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
-  it("업데이트할 멤버가 없으면 에러를 던진다", async () => {
+  it("수정할 필드가 하나도 없으면 에러를 던진다", async () => {
+    await expect(
+      updateMemberProfileUseCase({
+        spaceId: "space-1",
+        userId: 7,
+      }),
+    ).rejects.toThrow("수정할 프로필 정보가 없습니다.");
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("수정 대상 멤버가 없으면 에러를 던진다", async () => {
     mockUpdate.mockResolvedValue(undefined as never);
 
     await expect(
       updateMemberProfileUseCase({
-        nickname: "닉네임",
+        nickname: "새 닉네임",
         spaceId: "space-1",
         userId: 7,
       }),

--- a/apps/web/src/_pages/space/use-cases/update-member-profile.ts
+++ b/apps/web/src/_pages/space/use-cases/update-member-profile.ts
@@ -1,0 +1,35 @@
+import { type Member, memberQueries } from "@/entities/member";
+
+export interface UpdateMemberProfileInput {
+  avatarUrl?: string | null;
+  email?: string | null;
+  nickname: string;
+  spaceId: string;
+  userId: number;
+}
+
+export async function updateMemberProfileUseCase(input: UpdateMemberProfileInput): Promise<Member> {
+  const nickname = input.nickname.trim();
+  const email = input.email?.trim();
+  const avatarUrl = input.avatarUrl?.trim();
+
+  if (!nickname) {
+    throw new Error("닉네임을 입력해주세요.");
+  }
+
+  if (nickname.length > 20) {
+    throw new Error("닉네임은 20자 이하로 입력해주세요.");
+  }
+
+  const updatedMember = await memberQueries.update(input.spaceId, input.userId, {
+    avatarUrl: avatarUrl || null,
+    email: email || null,
+    nickname,
+  });
+
+  if (!updatedMember) {
+    throw new Error("멤버 정보를 찾을 수 없습니다.");
+  }
+
+  return updatedMember;
+}

--- a/apps/web/src/_pages/space/use-cases/update-member-profile.ts
+++ b/apps/web/src/_pages/space/use-cases/update-member-profile.ts
@@ -3,29 +3,44 @@ import { type Member, memberQueries } from "@/entities/member";
 export interface UpdateMemberProfileInput {
   avatarUrl?: string | null;
   email?: string | null;
-  nickname: string;
+  nickname?: string;
   spaceId: string;
   userId: number;
 }
 
 export async function updateMemberProfileUseCase(input: UpdateMemberProfileInput): Promise<Member> {
-  const nickname = input.nickname.trim();
-  const email = input.email?.trim();
-  const avatarUrl = input.avatarUrl?.trim();
+  // 유저가 변경 안하고 요청 시 omit처리 -> partial update
+  const updatePayload: Parameters<typeof memberQueries.update>[2] = {};
 
-  if (!nickname) {
-    throw new Error("닉네임을 입력해주세요.");
+  if (input.nickname !== undefined) {
+    const nickname = input.nickname.trim();
+
+    if (!nickname) {
+      throw new Error("닉네임을 입력해주세요.");
+    }
+
+    if (nickname.length > 20) {
+      throw new Error("닉네임은 20자 이하로 입력해주세요.");
+    }
+
+    updatePayload.nickname = nickname;
   }
 
-  if (nickname.length > 20) {
-    throw new Error("닉네임은 20자 이하로 입력해주세요.");
+  if (input.email !== undefined) {
+    const email = input.email?.trim();
+    updatePayload.email = email || null;
   }
 
-  const updatedMember = await memberQueries.update(input.spaceId, input.userId, {
-    avatarUrl: avatarUrl || null,
-    email: email || null,
-    nickname,
-  });
+  if (input.avatarUrl !== undefined) {
+    const avatarUrl = input.avatarUrl?.trim();
+    updatePayload.avatarUrl = avatarUrl || null;
+  }
+
+  if (Object.keys(updatePayload).length === 0) {
+    throw new Error("수정할 프로필 정보가 없습니다.");
+  }
+
+  const updatedMember = await memberQueries.update(input.spaceId, input.userId, updatePayload);
 
   if (!updatedMember) {
     throw new Error("멤버 정보를 찾을 수 없습니다.");


### PR DESCRIPTION
## 📌 Summary

스페이스 내부에서 본인 프로필 정보를 수정할 수 있도록 서버 액션과 유스케이스를 추가했습니다.

- close #94 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks

- `_pages/space/actions.ts`에 `updateMemberProfileAction` 추가
- 현재 스페이스의 `spaceId`와 현재 로그인한 유저의 `membership.userId`를 함께 사용해, 해당 스페이스에서 본인 멤버 정보만 수정되도록 처리
- `_pages/space/use-cases/update-member-profile.ts` 추가
- `nickname`, `email`, `avatarUrl` 입력값 정규화 및 최소 검증 로직 추가 -> 추가검증 필요 시 연동하면서 추가하겠습니다!
- 기존 `memberQueries.update(...)`를 호출해 `space_members` 테이블 업데이트
- 수정 후 `membership`, `members` 관련 태그와 경로 revalidate 처리


## 👀 To Reviewer

- 현재 구조는 `action -> use-case -> query -> DB` 흐름입니다.
- DB 직접 업데이트 로직은 기존 `memberQueries.update(...)`를 사용하고, 이번 PR에서는 스페이스 프로필 수정에 필요한 action/use-case를 추가했습니다.
- 현재 스페이스의 `spaceId`와 현재 유저의 `membership.userId`를 기준으로 수정 대상을 결정합니다.
- 이후 스페이스 내부 프로필 수정 모달과 연동작업 이어서 진행하겠습니다.

## 📸 Screenshot

_작업한 내용에 대한 스크린샷을 첨부해주세요._

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 멤버 프로필 업데이트 추가 (아바타, 이메일, 닉네임) — 페이지에서 즉시 변경 가능

* **개선 사항**
  * 닉네임 유효성 검사 강화(필수/공백 불가, 최대 20자)
  * 아바타·이메일 입력의 공백을 null로 정규화
  * 프로필 변경 시 관련 캐시 및 경로 자동 갱신

* **테스트**
  * 프로필 업데이트 로직 및 검증 경로에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->