### PR TITLE
[feat] gnb 마이페이지 진입 추가

### DIFF
--- a/apps/web/src/shared/config/routes.ts
+++ b/apps/web/src/shared/config/routes.ts
@@ -4,6 +4,7 @@ export const ROUTES = {
   moimCreate: "/moim-create",
   moimDetail: "/moim-detail",
   spaces: "/spaces",
+  mypage: "/mypage",
   login: "/login",
   signup: "/signup",
 } as const;

--- a/apps/web/src/shared/ui/navigation-menu-client.tsx
+++ b/apps/web/src/shared/ui/navigation-menu-client.tsx
@@ -4,12 +4,21 @@ import { Gnb, Sheet } from "@moum-zip/ui/components";
 import { Menu } from "@moum-zip/ui/icons";
 import Link from "next/link";
 import { logoutAction } from "@/_pages/auth/actions";
+import ProfileAvatar from "@/_pages/mypage/ui/profile-avatar";
 import Logo from "@/shared/assets/moum-zip-logo.svg";
 import { NAVIGATION_ROUTES, ROUTES } from "@/shared/config/routes";
 
 const logo = <Logo className="block h-8 w-auto" aria-hidden preserveAspectRatio="xMidYMid meet" />;
 
-export const NavigationMenuClient = ({ loggedIn }: { loggedIn: boolean }) => {
+type NavigationMenuClientProps = {
+  loggedIn: boolean;
+  user?: {
+    imageUrl?: string;
+    name?: string;
+  } | null;
+};
+
+export const NavigationMenuClient = ({ loggedIn, user }: NavigationMenuClientProps) => {
   return (
     <>
       <div className="hidden w-full py-2 md:block">
@@ -28,17 +37,36 @@ export const NavigationMenuClient = ({ loggedIn }: { loggedIn: boolean }) => {
               ))}
             </Gnb.Item>
           </Gnb.List>
-          <Gnb.List>
+          <Gnb.List className="items-center gap-1">
             {loggedIn ? (
-              <Gnb.Link asChild>
-                <button type="button" onClick={() => logoutAction()}>
-                  로그아웃
-                </button>
-              </Gnb.Link>
+              <>
+                <Gnb.Item>
+                  <Gnb.Link asChild>
+                    <button type="button" onClick={() => logoutAction()}>
+                      로그아웃
+                    </button>
+                  </Gnb.Link>
+                </Gnb.Item>
+                <Gnb.Item>
+                  <Link
+                    href={ROUTES.mypage}
+                    aria-label="마이페이지로 이동"
+                    className="inline-flex shrink-0 rounded-full transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-1"
+                  >
+                    <ProfileAvatar
+                      className="size-11 border-border"
+                      src={user?.imageUrl}
+                      alt={user?.name ? `${user.name} 프로필 이미지` : "프로필 이미지"}
+                    />
+                  </Link>
+                </Gnb.Item>
+              </>
             ) : (
-              <Gnb.Link asChild>
-                <Link href={ROUTES.login}>로그인</Link>
-              </Gnb.Link>
+              <Gnb.Item>
+                <Gnb.Link asChild>
+                  <Link href={ROUTES.login}>로그인</Link>
+                </Gnb.Link>
+              </Gnb.Item>
             )}
           </Gnb.List>
         </Gnb>
@@ -73,6 +101,15 @@ export const NavigationMenuClient = ({ loggedIn }: { loggedIn: boolean }) => {
                   </Sheet.Close>
                 </Sheet.Item>
               ))}
+              {loggedIn ? (
+                <Sheet.Item>
+                  <Sheet.Close asChild>
+                    <Link href={ROUTES.mypage} className="block rounded-md p-3 font-medium text-sm">
+                      마이페이지
+                    </Link>
+                  </Sheet.Close>
+                </Sheet.Item>
+              ) : null}
             </Sheet.List>
             <Sheet.Footer>
               {loggedIn ? (

--- a/apps/web/src/shared/ui/navigation-menu.tsx
+++ b/apps/web/src/shared/ui/navigation-menu.tsx
@@ -1,7 +1,4 @@
-import { Users } from "@moum-zip/api";
-import { cookies } from "next/headers";
-import { isAuth } from "@/shared/api/server";
-import { ACCESS_TOKEN_COOKIE } from "@/shared/lib/cookies";
+import { getApi, isAuth } from "@/shared/api/server";
 import { NavigationMenuClient } from "./navigation-menu-client";
 
 type NavigationUser = {
@@ -10,26 +7,9 @@ type NavigationUser = {
 };
 
 async function getNavigationUser(): Promise<NavigationUser | null> {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
-  const teamId = process.env.NEXT_PUBLIC_TEAM_ID;
-
-  if (!baseUrl || !teamId) {
-    return null;
-  }
-
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
-
-  if (!accessToken) {
-    return null;
-  }
-
   try {
-    const usersApi = new Users({
-      baseUrl,
-      securityWorker: () => ({ headers: { Authorization: `Bearer ${accessToken}` } }),
-    });
-    const response = await usersApi.getUsers(teamId);
+    const api = await getApi();
+    const response = await api.user.getUser();
 
     return {
       imageUrl: response.data.image ?? undefined,

--- a/apps/web/src/shared/ui/navigation-menu.tsx
+++ b/apps/web/src/shared/ui/navigation-menu.tsx
@@ -1,7 +1,49 @@
+import { Users } from "@moum-zip/api";
+import { cookies } from "next/headers";
 import { isAuth } from "@/shared/api/server";
+import { ACCESS_TOKEN_COOKIE } from "@/shared/lib/cookies";
 import { NavigationMenuClient } from "./navigation-menu-client";
+
+type NavigationUser = {
+  imageUrl?: string;
+  name?: string;
+};
+
+async function getNavigationUser(): Promise<NavigationUser | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+  const teamId = process.env.NEXT_PUBLIC_TEAM_ID;
+
+  if (!baseUrl || !teamId) {
+    return null;
+  }
+
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
+
+  if (!accessToken) {
+    return null;
+  }
+
+  try {
+    const usersApi = new Users({
+      baseUrl,
+      securityWorker: () => ({ headers: { Authorization: `Bearer ${accessToken}` } }),
+    });
+    const response = await usersApi.getUsers(teamId);
+
+    return {
+      imageUrl: response.data.image ?? undefined,
+      name: response.data.name ?? undefined,
+    };
+  } catch {
+    return null;
+  }
+}
 
 export async function NavigationMenu() {
   const { authenticated } = await isAuth();
-  return <NavigationMenuClient loggedIn={authenticated} />;
+
+  const user = authenticated ? await getNavigationUser() : null;
+
+  return <NavigationMenuClient loggedIn={authenticated} user={user} />;
 }

--- a/apps/web/src/shared/ui/navigation-menu.tsx
+++ b/apps/web/src/shared/ui/navigation-menu.tsx
@@ -13,7 +13,7 @@ async function getNavigationUser(): Promise<NavigationUser | null> {
 
     return {
       imageUrl: response.data.image ?? undefined,
-      name: response.data.name ?? undefined,
+      name: response.data.name,
     };
   } catch {
     return null;


### PR DESCRIPTION
## 📌 Summary

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- close #99 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- 상단 GNB 우측에 사용자 프로필 아바타를 추가했습니다.
- 프로필 이미지가 없을 경우 기본 프로필 아이콘이 노출되도록 fallback을 적용했습니다.
- 프로필 아바타 클릭 시 마이페이지로 이동하도록 연결했습니다.
- 모바일 햄버거 메뉴에 마이페이지 링크를 추가했습니다.

## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

- 데스크톱 GNB 우측 프로필 아바타 노출 위치와 크기가 의도한 UI와 맞는지 확인 부탁드립니다.

## 📸 Screenshot

_작업한 내용에 대한 스크린샷을 첨부해주세요._

![Mar-31-2026 17-41-15](https://github.com/user-attachments/assets/962feb9d-5075-4c02-b00e-eccc0a819e60)

<img width="1348" height="787" alt="스크린샷 2026-03-31 오후 5 43 23" src="https://github.com/user-attachments/assets/30e8d0dd-f8b8-4111-b6b6-ba5e6ef13580" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지 라우트("/mypage") 추가
  * 네비게이션 메뉴에 마이페이지 링크 및 항목 추가(데스크탑·모바일 모두)
  * 로그인 시 서버에서 사용자 프로필을 가져와 네비게이션에 프로필 이미지와 이름을 표시
  * 인증되지 않거나 프로필 로드 실패 시 기존 동작을 유지하도록 조건부 표시 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->