### PR TITLE
[refactor] 모임 만들기 페이지 TimePicker UX 개선 및 유효성 검증 강화

### DIFF
--- a/apps/web/src/_pages/moim-create/lib/date-time.test.ts
+++ b/apps/web/src/_pages/moim-create/lib/date-time.test.ts
@@ -36,8 +36,8 @@ describe("parseTimeString", () => {
     expect(result).toEqual({ hour: "14", minute: "30" });
   });
 
-  it("undefined이면 기본값 00:00을 반환", () => {
-    expect(parseTimeString(undefined)).toEqual({ hour: "00", minute: "00" });
+  it("undefined이면 빈 문자열을 반환", () => {
+    expect(parseTimeString(undefined)).toEqual({ hour: "", minute: "" });
   });
 });
 

--- a/apps/web/src/_pages/moim-create/lib/date-time.ts
+++ b/apps/web/src/_pages/moim-create/lib/date-time.ts
@@ -16,8 +16,8 @@ export const formatDate = (date: Date): string => {
 
 // "00:00" 형식의 문자열을 { hour, minute } 객체로 변환
 export const parseTimeString = (value: string | undefined): { hour: string; minute: string } => {
-  if (!value) return { hour: "00", minute: "00" };
-  const [hour = "00", minute = "00"] = value.split(":");
+  if (!value) return { hour: "", minute: "" };
+  const [hour = "", minute = ""] = value.split(":");
   return { hour, minute };
 };
 

--- a/apps/web/src/_pages/moim-create/ui/date-picker.tsx
+++ b/apps/web/src/_pages/moim-create/ui/date-picker.tsx
@@ -5,6 +5,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@ui/components/shadcn/p
 import { CalendarIcon } from "@ui/icons";
 import { useState } from "react";
 import { formatDate, parseDateString } from "@/_pages/moim-create/lib/date-time";
+import { cn } from "@/shared/lib/cn";
 
 interface DatePickerProps {
   value?: string;
@@ -30,7 +31,9 @@ export const DatePicker = ({ value, onChange }: DatePickerProps) => {
           className="flex items-center gap-2 rounded-md border border-input p-3"
         >
           <CalendarIcon className="size-4 text-muted-foreground" />
-          <span className="text-sm leading-[22px]">{value || "YYYY-MM-DD"}</span>
+          <span className={cn("text-sm leading-[22px]", value ? "text-foreground" : "text-muted-foreground")}>
+            {value || "YYYY-MM-DD"}
+          </span>
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-auto">

--- a/apps/web/src/_pages/moim-create/ui/time-picker.tsx
+++ b/apps/web/src/_pages/moim-create/ui/time-picker.tsx
@@ -2,6 +2,7 @@
 
 import { Popover, PopoverContent, PopoverTrigger } from "@ui/components/shadcn/popover";
 import { ClockIcon } from "@ui/icons";
+import { useState } from "react";
 import { formatTime, parseTimeString } from "@/_pages/moim-create/lib/date-time";
 import { cn } from "@/shared/lib/cn";
 
@@ -14,18 +15,21 @@ const hours = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, "0"));
 const minutes = Array.from({ length: 6 }, (_, i) => String(i * 10).padStart(2, "0"));
 
 export const TimePicker = ({ value, onChange }: TimePickerProps) => {
+  const [open, setOpen] = useState(false);
   const { hour, minute } = parseTimeString(value);
 
   const handleHourSelect = (h: string) => {
     onChange?.(formatTime(h, minute));
+    if (minute) setOpen(false);
   };
 
   const handleMinuteSelect = (m: string) => {
     onChange?.(formatTime(hour, m));
+    if (hour) setOpen(false);
   };
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -38,7 +42,7 @@ export const TimePicker = ({ value, onChange }: TimePickerProps) => {
           </span>
         </button>
       </PopoverTrigger>
-      <PopoverContent className="flex w-auto flex-row gap-2 p-2">
+      <PopoverContent align="start" className="flex w-auto flex-row gap-2 p-2">
         {/* hour 컬럼 */}
         <ul className="no-scrollbar h-[184px] overflow-y-scroll">
           {hours.map((h) => (
@@ -46,7 +50,7 @@ export const TimePicker = ({ value, onChange }: TimePickerProps) => {
               <button
                 type="button"
                 className={cn(
-                  "w-12 rounded px-2 py-1 text-sm hover:bg-primary/20 hover:text-foreground",
+                  "w-12 rounded px-2 py-1 text-sm hover:bg-accent hover:text-foreground",
                   h === hour && "bg-primary text-white",
                 )}
                 onClick={() => handleHourSelect(h)}
@@ -63,7 +67,7 @@ export const TimePicker = ({ value, onChange }: TimePickerProps) => {
               <button
                 type="button"
                 className={cn(
-                  "w-12 rounded px-2 py-1 text-sm hover:bg-primary/20 hover:text-foreground",
+                  "w-12 rounded px-2 py-1 text-sm hover:bg-accent hover:text-foreground",
                   m === minute && "bg-primary text-white",
                 )}
                 onClick={() => handleMinuteSelect(m)}

--- a/apps/web/src/_pages/moim-create/ui/time-picker.tsx
+++ b/apps/web/src/_pages/moim-create/ui/time-picker.tsx
@@ -33,7 +33,9 @@ export const TimePicker = ({ value, onChange }: TimePickerProps) => {
           className="flex items-center gap-2 rounded-md border border-input p-3"
         >
           <ClockIcon className="size-4 text-muted-foreground" />
-          <span className="text-sm leading-[22px]"> {value ? value.replace(":", " : ") : "HH : MM"}</span>
+          <span className={cn("text-sm leading-[22px]", value ? "text-foreground" : "text-muted-foreground")}>
+            {value ? value.replace(":", " : ") : "HH : MM"}
+          </span>
         </button>
       </PopoverTrigger>
       <PopoverContent className="flex w-auto flex-row gap-2 p-2">

--- a/apps/web/src/_pages/moim-create/ui/time-picker.tsx
+++ b/apps/web/src/_pages/moim-create/ui/time-picker.tsx
@@ -45,7 +45,10 @@ export const TimePicker = ({ value, onChange }: TimePickerProps) => {
             <li key={h}>
               <button
                 type="button"
-                className={cn("w-12 rounded px-2 py-1 text-sm", h === hour && "bg-primary text-white")}
+                className={cn(
+                  "w-12 rounded px-2 py-1 text-sm hover:bg-primary/20 hover:text-foreground",
+                  h === hour && "bg-primary text-white",
+                )}
                 onClick={() => handleHourSelect(h)}
               >
                 {h}
@@ -59,7 +62,10 @@ export const TimePicker = ({ value, onChange }: TimePickerProps) => {
             <li key={m}>
               <button
                 type="button"
-                className={cn("w-12 rounded px-2 py-1 text-sm", m === minute && "bg-primary text-white")}
+                className={cn(
+                  "w-12 rounded px-2 py-1 text-sm hover:bg-primary/20 hover:text-foreground",
+                  m === minute && "bg-primary text-white",
+                )}
                 onClick={() => handleMinuteSelect(m)}
               >
                 {m}

--- a/apps/web/src/_pages/moim-create/ui/time-picker.tsx
+++ b/apps/web/src/_pages/moim-create/ui/time-picker.tsx
@@ -11,7 +11,7 @@ interface TimePickerProps {
 }
 
 const hours = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, "0"));
-const minutes = Array.from({ length: 60 }, (_, i) => String(i).padStart(2, "0"));
+const minutes = Array.from({ length: 6 }, (_, i) => String(i * 10).padStart(2, "0"));
 
 export const TimePicker = ({ value, onChange }: TimePickerProps) => {
   const { hour, minute } = parseTimeString(value);

--- a/apps/web/src/features/moim-create/model/schema.test.ts
+++ b/apps/web/src/features/moim-create/model/schema.test.ts
@@ -76,4 +76,32 @@ describe("moimCreateSchema", () => {
     expect(result.success).toBe(false);
     expect(result.error?.issues[0].message).toBe("1명 이상 입력해주세요.");
   });
+
+  it("모임 시간이 시만 있으면 분 선택 메시지", () => {
+    const result = moimCreateSchema.safeParse({ ...baseInput, time: "14:" });
+    expect(result.success).toBe(false);
+    const issue = result.error?.issues.find((i) => i.path[0] === "time");
+    expect(issue?.message).toBe("분을 선택해주세요.");
+  });
+
+  it("모임 시간이 분만 있으면 시 선택 메시지", () => {
+    const result = moimCreateSchema.safeParse({ ...baseInput, time: ":30" });
+    expect(result.success).toBe(false);
+    const issue = result.error?.issues.find((i) => i.path[0] === "time");
+    expect(issue?.message).toBe("시를 선택해주세요.");
+  });
+
+  it("모임 시간이 비어있으면 실패", () => {
+    const result = moimCreateSchema.safeParse({ ...baseInput, time: "" });
+    expect(result.success).toBe(false);
+    const issue = result.error?.issues.find((i) => i.path[0] === "time");
+    expect(issue?.message).toBe("모임 시간을 선택해주세요.");
+  });
+
+  it("마감 시간이 분만 있으면 시 선택 메시지", () => {
+    const result = moimCreateSchema.safeParse({ ...baseInput, deadlineTime: ":30" });
+    expect(result.success).toBe(false);
+    const issue = result.error?.issues.find((i) => i.path[0] === "deadlineTime");
+    expect(issue?.message).toBe("시를 선택해주세요.");
+  });
 });

--- a/apps/web/src/features/moim-create/model/schema.ts
+++ b/apps/web/src/features/moim-create/model/schema.ts
@@ -4,9 +4,50 @@ import { z } from "zod";
 const spaceFunctionSchema = z.enum(["bulletin", "schedule", "members"]);
 export type SpaceFunction = z.infer<typeof spaceFunctionSchema>;
 
+// utils
 const toDateTime = (date: string, time: string) => new Date(`${date}T${time}`);
 const isValidDate = (date: Date) => !Number.isNaN(date.getTime());
 
+// time field schema
+// 피커에서 "12:" / ":30" 같은 중간 입력 상태도 들어올 수 있어서 케이스별로 분기 처리
+function timeFieldSchema(requiredMessage: string) {
+  return z
+    .string()
+    .min(1, requiredMessage)
+    .superRefine((value, ctx) => {
+      const isFullTime = /^\d{2}:\d{2}$/.test(value); // ex. 12:30
+      const isHourOnly = /^\d{2}:$/.test(value); // ex. 12:
+      const isMinuteOnly = /^:\d{2}$/.test(value); // ex. :30
+
+      if (isFullTime) {
+        const h = Number(value.slice(0, 2));
+        const m = Number(value.slice(3, 5));
+
+        // 시간 범위 검증 (24h 기준)
+        if (h > 23 || m > 59) {
+          ctx.addIssue({ code: "custom", message: "올바른 시간을 선택해주세요." });
+        }
+        return;
+      }
+
+      // 시간만 선택된 경우
+      if (isHourOnly) {
+        ctx.addIssue({ code: "custom", message: "분을 선택해주세요." });
+        return;
+      }
+
+      // 분만 선택된 경우
+      if (isMinuteOnly) {
+        ctx.addIssue({ code: "custom", message: "시를 선택해주세요." });
+        return;
+      }
+
+      // 둘 다 선택 안 된 경우
+      ctx.addIssue({ code: "custom", message: "시와 분을 모두 선택해주세요." });
+    });
+}
+
+// main schema
 export const moimCreateSchema = z
   .object({
     type: z.enum(["study", "project"], { error: "모임 종류를 선택해주세요." }),
@@ -19,9 +60,9 @@ export const moimCreateSchema = z
     image: z.string().min(1, "이미지를 첨부해주세요."),
     location: z.enum(["online", "offline"], { error: "장소를 선택해주세요." }),
     date: z.string().min(1, "모임 날짜를 선택해주세요."),
-    time: z.string().min(1, "모임 시간을 선택해주세요."),
+    time: timeFieldSchema("모임 시간을 선택해주세요."),
     deadlineDate: z.string().min(1, "마감 날짜를 선택해주세요."),
-    deadlineTime: z.string().min(1, "마감 시간을 선택해주세요."),
+    deadlineTime: timeFieldSchema("마감 시간을 선택해주세요."),
     themeColor: z.string().min(1, "테마 색상을 선택해주세요."),
     options: spaceFunctionSchema.array().optional(),
   })
@@ -30,14 +71,17 @@ export const moimCreateSchema = z
     const moimDateTime = toDateTime(data.date, data.time);
     const deadlineDateTime = toDateTime(data.deadlineDate, data.deadlineTime);
 
+    // 모임 시간 검증
     if (isValidDate(moimDateTime) && moimDateTime <= now) {
       ctx.addIssue({ code: "custom", message: "모임 일시는 현재 시각 이후여야 합니다.", path: ["date"] });
     }
 
+    // 마감 시간 검증
     if (isValidDate(deadlineDateTime) && deadlineDateTime <= now) {
       ctx.addIssue({ code: "custom", message: "모집 마감 일시는 현재 시각 이후여야 합니다.", path: ["deadlineDate"] });
     }
 
+    // 마감 < 모임 검증
     if (isValidDate(moimDateTime) && isValidDate(deadlineDateTime) && deadlineDateTime >= moimDateTime) {
       const message = "모집 마감 일시는 모임 일시 이전이어야 합니다.";
       ctx.addIssue({ code: "custom", message, path: ["deadlineDate"] });

--- a/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
+++ b/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
@@ -3,7 +3,6 @@
 import { Button, CategoryTab, FileInput, InputField, InputTextArea } from "@ui/components";
 import { RadioGroup, RadioGroupItem } from "@ui/components/shadcn/radio-group";
 import Image from "next/image";
-import type { BaseSyntheticEvent } from "react";
 import { Controller, type UseFormReturn } from "react-hook-form";
 import { DatePicker, icoProject, icoStudy, TimePicker } from "@/_pages/moim-create";
 import type { MoimCreateFormValues } from "@/features/moim-create/model/schema";


### PR DESCRIPTION
## 📌 Summary

TimePicker UX 개선 및 시간 필드 유효성 검증 강화

- close #109

## 📄 Tasks

### UX 개선
- 분(minute) 선택을 10분 단위로 제한
- 시/분 선택 시 Picker 팝업 자동 닫힘 처리
- TimePicker 항목 hover 스타일 추가
- Date/Time Picker 플레이스 홀더 텍스트 색상 수정

### 사용성 개선
- `parseTimeString` 기본값 `"00"`->  `""`으로 변경 
-> 시간 미선택 시, `00:00`이 강조되어 이미 선택된 것처럼 보이는 문제 개선

### validation 강화
- timeFieldSchema 및 테스트 추가
- `14:`, `:30` 같은 중간 입력 상태까지 고려하여 validation 처리

## 👀 To Reviewer

- timeFieldSchema에서 "14:", ":30" 같은 중간 입력 상태를 케이스별로 분기했는데 이 방식이 적절한지 확인 부탁드립니다!

## 📸 Screenshot
**Before**

https://github.com/user-attachments/assets/9bafe21d-498b-47b4-a6cc-708ac8750ccf
- 시/분 선택 후에도 Popover가 자동으로 닫히지 않아, 외부 영역을 추가 클릭해야 하는 UX 불편이 있었습니다.

**After**

https://github.com/user-attachments/assets/5854f1b4-b672-4c5d-904a-e83ec0e70b52


https://github.com/user-attachments/assets/16747449-4645-4162-bb52-19f6048b6211



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 시간 선택기의 분 옵션을 10분 단위로 개선하여 선택 편의성 향상
  * 팝오버 상태 제어 추가로 사용자 경험 개선

* **Bug Fixes**
  * 불완전한 시간 입력(시 또는 분만 입력)에 대한 유효성 검증 강화 및 명확한 오류 메시지 추가

* **Style**
  * 날짜·시간 입력 필드의 조건부 스타일링으로 값 입력 상태 시각적 구분 개선

* **Tests**
  * 시간 필드 유효성 검증에 대한 테스트 케이스 추가

* **Chores**
  * 불필요한 import 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->