### PR TITLE
[feat] cache-key 파일 생성 및 unstabe_cache 헬퍼 함수 추가

### DIFF
--- a/apps/web/src/shared/lib/cache-keys.ts
+++ b/apps/web/src/shared/lib/cache-keys.ts
@@ -1,0 +1,72 @@
+import { unstable_cache } from "next/cache";
+/**
+ * unstable_cache의 두 번째 인자 (keyParts).
+ * Next.js Data Cache에서 항목을 식별하는 기본 키.
+ * 인자가 다르면 자동으로 다른 캐시 항목으로 저장된다.
+ */
+export const CACHE_KEYS = {
+  spaceInfo: "space-info",
+  spaceBySlug: "space-by-slug",
+  spaceMembership: "space-membership",
+  bulletinPosts: "bulletin-posts",
+  postDetail: "post-detail",
+  schedules: "schedules",
+  spaceMembers: "space-members",
+  spaceAllMembers: "space-all-members",
+  spaceList: "space-list",
+} as const;
+
+/**
+ * revalidateTag / unstable_cache tags 옵션에 사용하는 태그.
+ * mutation 후 이 태그를 revalidateTag에 전달하면 관련 캐시가 무효화된다.
+ *
+ * @example
+ * revalidateTag(CACHE_TAGS.bulletin(spaceId));
+ */
+export const CACHE_TAGS = {
+  space: (slug: string) => `space-${slug}`,
+  bulletin: (spaceId: string) => `bulletin-${spaceId}`,
+  post: (postId: string) => `post-${postId}`,
+  schedules: (spaceId: string) => `schedules-${spaceId}`,
+  members: (spaceId: string) => `members-${spaceId}`,
+  membership: (spaceId: string) => `membership-${spaceId}`,
+  spaceList: (userId: string) => `space-list-${userId}`,
+} as const;
+
+/**
+ * unstable_cache의 revalidate 옵션 기준값.
+ * NEVER: 명시적 revalidateTag로만 무효화 (자주 변하지 않는 데이터).
+ */
+export const CACHE_TTL = {
+  NEVER: false as const,
+  SHORT: 30,
+  MEDIUM: 60,
+  LONG: 3600,
+} as const;
+
+/**
+ * 동적 태그를 갖는 unstable_cache 인스턴스를 lazy하게 생성하는 팩토리.
+ *
+ * @example
+ * const getBulletinPostsCached = createTaggedCache(
+ *   fetchBulletinPosts,
+ *   (spaceId) => ({ key: [CACHE_KEYS.bulletinPosts, spaceId], tags: [CACHE_TAGS.bulletin(spaceId)], revalidate: CACHE_TTL.SHORT }),
+ * );
+ * export const getBulletinPostsUseCase = (spaceId: string, opts: BulletinOpts) =>
+ *   getBulletinPostsCached(spaceId)(spaceId, opts);
+ */
+type Callback = (...args: any[]) => Promise<unknown>;
+
+export function createTaggedCache<T extends Callback>(
+  fn: T,
+  optsFn: (id: string) => { key: string[]; tags: string[]; revalidate: number | false },
+): (id: string) => T {
+  const cache = new Map<string, T>();
+  return (id: string): T => {
+    if (!cache.has(id)) {
+      const { key, tags, revalidate } = optsFn(id);
+      cache.set(id, unstable_cache(fn, key, { tags, revalidate }) as T);
+    }
+    return cache.get(id)!;
+  };
+}


### PR DESCRIPTION
## 📌 Summary

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

cache-key를 중앙에서 관리하도록 파일과 변수 생성하고 헬퍼함수 추가했습니다.

- close #111 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- CACHE_KEYS, CACHE_TAGS, CACHE_TTL 상수 추가
- `createTaggedCache` 헬퍼 함수 추가

관련 사용법과 컨벤션은 노션 개발 기록 > unstable_cache 컨벤션에 자세히 기록해두었습니다. 
  

## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

- CACHE_KEYS, CACHE_TAGS에 필요한 변수 추가해주세요

## 📸 Screenshot

_작업한 내용에 대한 스크린샷을 첨부해주세요._

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

이 릴리스에는 사용자에게 직접 보이는 기능 변경 사항이 없습니다. 내부 인프라 최적화만 포함되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->