### PR TITLE
[fix] 참가 대기 멤버 use-case 및 ui 수정

### DIFF
--- a/apps/web/src/_pages/members/ui/pending-member-card.tsx
+++ b/apps/web/src/_pages/members/ui/pending-member-card.tsx
@@ -74,15 +74,17 @@ export function PendingMemberCard({ pendingMembers, onAccept }: PendingMemberCar
 
   const visible = pendingMembers.filter((m) => !rejectedIds.has(m.userId) && !acceptedIds.has(m.userId));
 
-  if (visible.length === 0) return null;
-
   return (
     <div className="rounded-lg border border-primary/20 bg-background p-5">
       <span className="mb-1 block font-semibold text-base text-foreground">참가를 요청한 사용자</span>
       <div className="flex flex-col gap-2">
-        {visible.map((member) => (
-          <ParticipantRow key={member.userId} member={member} onAccept={handleAccept} onReject={handleReject} />
-        ))}
+        {visible.length === 0 ? (
+          visible.map((member) => (
+            <ParticipantRow key={member.userId} member={member} onAccept={handleAccept} onReject={handleReject} />
+          ))
+        ) : (
+          <span className="py-4 text-center text-neutral-400 text-sm">참가 대기 중인 사용자가 없어요.</span>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/_pages/members/use-cases/get-pending-members.ts
+++ b/apps/web/src/_pages/members/use-cases/get-pending-members.ts
@@ -1,3 +1,4 @@
+import { memberQueries } from "@/entities/member";
 import { getApi } from "@/shared/api/server";
 import { safe } from "@/shared/lib/safe";
 
@@ -15,17 +16,22 @@ export interface GetPendingMembersResult {
  * 스페이스(미팅)의 대기 중인 참가자 목록 조회.
  * joinedAt이 null인 참가자를 대기 중으로 간주한다.
  */
-export async function getPendingMembersRemote(meetingId: number): Promise<GetPendingMembersResult> {
+export async function getPendingMembersUseCase(spaceId: string): Promise<GetPendingMembersResult> {
   const api = await getApi();
 
-  const { data } = await safe(api.meetings.participants.getList(meetingId, { size: 100 }), {
+  const { data } = await safe(api.meetings.participants.getList(Number(spaceId), { size: 20 }), {
     default: () => {
       throw new Error("Failed to fetch pending members");
     },
   });
 
-  const pendingMembers: PendingMember[] = data.data
-    .filter((p) => p.joinedAt === null)
+  const participants = data.data;
+
+  const members = await memberQueries.findUserIdsBySpaceId(spaceId);
+  const memberUserIdSet = new Set(members.map((m) => m.userId));
+
+  const pendingMembers: PendingMember[] = participants
+    .filter((p) => !memberUserIdSet.has(p.userId))
     .map((p) => ({
       userId: p.userId,
       name: p.user?.name ?? "Unknown",

--- a/apps/web/src/app/[space-slug]/members/_components/member-right-section.tsx
+++ b/apps/web/src/app/[space-slug]/members/_components/member-right-section.tsx
@@ -1,6 +1,6 @@
 import { OnlineNowCard, PendingMemberCard, RolesOverviewCard } from "@/_pages/members";
 import { addSpaceMemberAction } from "@/_pages/members/action";
-import { getPendingMembersRemote } from "@/_pages/members/use-cases/get-pending-members";
+import { getPendingMembersUseCase } from "@/_pages/members/use-cases/get-pending-members";
 import { queryAllMembersUseCase } from "@/_pages/members/use-cases/query-all-members";
 import type { SpaceInfo } from "@/entities/spaces";
 import { hasPermission } from "@/features/space";
@@ -14,9 +14,7 @@ interface MemberRightSectionProps {
 export const MemberRightSection = async ({ space, membership }: MemberRightSectionProps) => {
   const [allMembers, { pendingMembers }] = await Promise.all([
     queryAllMembersUseCase(space.spaceId),
-    membership.role === "manager"
-      ? getPendingMembersRemote(Number(space.spaceId))
-      : Promise.resolve({ pendingMembers: [] }),
+    membership.role === "manager" ? getPendingMembersUseCase(space.spaceId) : Promise.resolve({ pendingMembers: [] }),
   ]);
 
   const acceptMember = addSpaceMemberAction.bind(null, space.slug);

--- a/apps/web/src/entities/member/queries.ts
+++ b/apps/web/src/entities/member/queries.ts
@@ -12,6 +12,9 @@ export const memberQueries = {
       sql`${spaceMembers.nickname} ASC`, // 닉네임 가나다순
     );
   },
+  findUserIdsBySpaceId: async (spaceId: string) => {
+    return db.select({ userId: spaceMembers.userId }).from(spaceMembers).where(eq(spaceMembers.spaceId, spaceId));
+  },
   findManyBySpaceId: async (spaceId: string, opts?: { limit?: number; offset?: number }) => {
     return db
       .select({


### PR DESCRIPTION
## 📌 Summary

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

참가 대기하는 멤버를 보여주는 로직과 UI 변경

- close #127 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- 외부 api 서버에서 `participants` 데이터를 받고 내부 스페이스 멤버인지 검증하는 로직을 추가하였습니다.
- `pending member`를 보여주는 ui를 조금 수정했습니다. 

## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

-

## 📸 Screenshot

_작업한 내용에 대한 스크린샷을 첨부해주세요._

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 참가 대기 중인 사용자가 없을 때 안내 메시지를 표시하도록 개선했습니다.

* **개선사항**
  * 참가 대기 목록 조회 로직이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->