### PR TITLE
[fix] mypage 내가 만든 모임 목록 조회 오류 수정

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -18,6 +18,12 @@ const nextConfig: NextConfig = {
         port: "",
         pathname: "/**", // 모든 경로의 이미지를 허용
       },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        port: "",
+        pathname: "/**",
+      },
     ],
   },
   turbopack: {

--- a/apps/web/src/_pages/mypage/hooks/use-created-meetings.ts
+++ b/apps/web/src/_pages/mypage/hooks/use-created-meetings.ts
@@ -13,6 +13,7 @@ export const useCreatedMeetings = (
     queryKey: ["mypage", "meetings", "created", createdFilter],
     queryFn: () => getCreatedMeetingCards(createdFilter),
     initialData,
+    staleTime: 0,
     enabled,
   });
 };

--- a/apps/web/src/_pages/mypage/queries/server.ts
+++ b/apps/web/src/_pages/mypage/queries/server.ts
@@ -1,7 +1,4 @@
-import { Meetings } from "@moum-zip/api";
-import { cookies } from "next/headers";
 import { getApi } from "@/shared/api/server";
-import { ACCESS_TOKEN_COOKIE } from "@/shared/lib/cookies";
 
 export interface MyMeetingsServerQuery {
   type: "joined" | "created";
@@ -13,30 +10,10 @@ export interface MyMeetingsServerQuery {
   cursor?: string;
 }
 
-const getCreatedMeetingsApi = async () => {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
-  const teamId = process.env.NEXT_PUBLIC_TEAM_ID;
-
-  if (!baseUrl || !teamId) {
-    throw new Error("MYPAGE_SERVER_CONFIG_MISSING");
-  }
-
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
-
-  return {
-    meetingsApi: new Meetings({
-      baseUrl,
-      securityWorker: () => (accessToken ? { headers: { Authorization: `Bearer ${accessToken}` } } : {}),
-    }),
-    teamId,
-  };
-};
-
 export const getMyMeetings = async (query: MyMeetingsServerQuery) => {
-  if (query.type === "joined") {
-    const api = await getApi();
+  const api = await getApi();
 
+  if (query.type === "joined") {
     return api.meetings.getJoined({
       completed: query.completed,
       reviewed: query.reviewed,
@@ -50,9 +27,7 @@ export const getMyMeetings = async (query: MyMeetingsServerQuery) => {
     });
   }
 
-  const { meetingsApi, teamId } = await getCreatedMeetingsApi();
-
-  return meetingsApi.getMeetings(teamId, {
+  return api.meetings.getCreated({
     sortBy:
       query.sortBy === "dateTime" || query.sortBy === "registrationEnd" || query.sortBy === "participantCount"
         ? query.sortBy

--- a/apps/web/src/shared/api/index.ts
+++ b/apps/web/src/shared/api/index.ts
@@ -128,7 +128,10 @@ function buildApiShape(core: {
         query?: Parameters<typeof core.meetings.joinedList>[1],
         params?: Parameters<typeof core.meetings.joinedList>[2],
       ) => core.meetings.joinedList(teamId, query, params),
-      getCreated: () => core.meetings.getMeetings(teamId),
+      getCreated: (
+        query?: Parameters<typeof core.meetings.getMeetings>[1],
+        params?: Parameters<typeof core.meetings.getMeetings>[2],
+      ) => core.meetings.getMeetings(teamId, query, params),
       getList: (
         query?: Parameters<typeof core.meetings.meetingsList>[1],
         params?: Parameters<typeof core.meetings.meetingsList>[2],


### PR DESCRIPTION
## 📌 Summary

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- close #130 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- created 목록 조회 경로를 joined와 동일한 getApi() 기반 인증 흐름으로 정리
- 내가 만든 모임 탭의 빈 초기값이 60초 동안 fresh 상태로 유지되던 문제를 수정해 탭 진입 시 즉시 조회되도록 변경
- Google 프로필 이미지 URL(lh3.googleusercontent.com)이 next/image에서 정상 렌더링되도록 next.config 설정 추가

## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

- 마이페이지 created 탭의 즉시 조회 처리 방식이 구조상 무리가 없는지 확인 부탁드립니다.

## 📸 Screenshot

_작업한 내용에 대한 스크린샷을 첨부해주세요._

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 외부 이미지 로딩 최적화로 더 빠른 화면 표시 제공
  * 내 모임 페이지의 생성된 모임 목록이 더 자주 새로운 정보로 업데이트되도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->