### PR TITLE
[fix] 인증 UX 개선 및 라우팅 설정 수정

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -18,6 +18,24 @@ const nextConfig: NextConfig = {
         port: "",
         pathname: "/**", // 모든 경로의 이미지를 허용
       },
+      {
+        protocol: "https",
+        hostname: "img1.kakaocdn.net", // 카카오 프로필 이미지
+        port: "",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "t1.kakaocdn.net", // 카카오 기본 프로필 이미지
+        port: "",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com", // 구글 프로필 이미지
+        port: "",
+        pathname: "/**",
+      },
     ],
   },
   turbopack: {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -31,6 +31,18 @@ const nextConfig: NextConfig = {
         pathname: "/**",
       },
       {
+        protocol: "http",
+        hostname: "img1.kakaocdn.net", // 카카오 프로필 이미지 (로컬 테스트용)
+        port: "",
+        pathname: "/**",
+      },
+      {
+        protocol: "http",
+        hostname: "t1.kakaocdn.net", // 카카오 기본 프로필 이미지 (로컬 테스트용)
+        port: "",
+        pathname: "/**",
+      },
+      {
         protocol: "https",
         hostname: "lh3.googleusercontent.com", // 구글 프로필 이미지
         port: "",

--- a/apps/web/src/app/oauth/callback/page.tsx
+++ b/apps/web/src/app/oauth/callback/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { LoadingIndicator } from "@moum-zip/ui/components";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useRef } from "react";
 import { ROUTES } from "@/shared/config/routes";
@@ -54,12 +55,12 @@ function OAuthCallbackContent() {
     handleCallback();
   }, [searchParams, router]);
 
-  return <div>로그인 처리 중...</div>;
+  return <LoadingIndicator fullScreen text="로그인 처리 중" />;
 }
 
 export default function OAuthCallbackPage() {
   return (
-    <Suspense fallback={<div>로그인 처리 중...</div>}>
+    <Suspense fallback={<LoadingIndicator fullScreen text="로그인 처리 중" />}>
       <OAuthCallbackContent />
     </Suspense>
   );

--- a/apps/web/src/features/auth/ui/login-form.tsx
+++ b/apps/web/src/features/auth/ui/login-form.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button, InputField, SocialButton } from "@moum-zip/ui/components";
+import { Button, InputField, LoadingIndicator, SocialButton } from "@moum-zip/ui/components";
 import Link from "next/link";
-import { startTransition, useActionState } from "react";
+import { startTransition, useActionState, useState } from "react";
 import { useForm } from "react-hook-form";
 import { loginAction } from "@/_pages/auth/actions";
 import { getGoogleLoginUrl, getKakaoLoginUrl } from "@/_pages/auth/use-cases/social-login-url";
@@ -24,6 +24,7 @@ const ERROR_MESSAGES = {
 export const LoginForm = () => {
   // 서버 액션 상태 관리
   const [state, formAction, isPending] = useActionState(loginAction, null);
+  const [isSocialLoading, setIsSocialLoading] = useState(false);
 
   const {
     register,
@@ -32,6 +33,9 @@ export const LoginForm = () => {
   } = useForm<LoginFormValues>({
     mode: "onBlur", // 필드 입력 완료 후 넘어갈 때 유효성 검사
   });
+
+  // 소셜 로그인 진행 중일 때 로딩 화면 표시
+  if (isSocialLoading) return <LoadingIndicator fullScreen text="로그인 중" />;
 
   // 유효성 검사 통과 후 → 서버 액션 호출
   const onSubmit = handleSubmit((data) => {
@@ -95,6 +99,7 @@ export const LoginForm = () => {
           provider="google"
           className="w-full md:w-[222px]"
           onClick={() => {
+            setIsSocialLoading(true);
             window.location.href = getGoogleLoginUrl();
           }}
         />
@@ -102,6 +107,7 @@ export const LoginForm = () => {
           provider="kakao"
           className="w-full md:w-[222px]"
           onClick={() => {
+            setIsSocialLoading(true);
             window.location.href = getKakaoLoginUrl();
           }}
         />

--- a/apps/web/src/features/auth/ui/login-form.tsx
+++ b/apps/web/src/features/auth/ui/login-form.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Button, InputField, LoadingIndicator, SocialButton } from "@moum-zip/ui/components";
+import { Button, InputField, SocialButton } from "@moum-zip/ui/components";
 import Link from "next/link";
-import { startTransition, useActionState, useState } from "react";
+import { startTransition, useActionState } from "react";
 import { useForm } from "react-hook-form";
 import { loginAction } from "@/_pages/auth/actions";
 import { getGoogleLoginUrl, getKakaoLoginUrl } from "@/_pages/auth/use-cases/social-login-url";
@@ -24,7 +24,6 @@ const ERROR_MESSAGES = {
 export const LoginForm = () => {
   // 서버 액션 상태 관리
   const [state, formAction, isPending] = useActionState(loginAction, null);
-  const [isSocialLoading, setIsSocialLoading] = useState(false);
 
   const {
     register,
@@ -33,9 +32,6 @@ export const LoginForm = () => {
   } = useForm<LoginFormValues>({
     mode: "onBlur", // 필드 입력 완료 후 넘어갈 때 유효성 검사
   });
-
-  // 소셜 로그인 진행 중일 때 로딩 화면 표시
-  if (isSocialLoading) return <LoadingIndicator fullScreen text="로그인 중" />;
 
   // 유효성 검사 통과 후 → 서버 액션 호출
   const onSubmit = handleSubmit((data) => {
@@ -99,7 +95,6 @@ export const LoginForm = () => {
           provider="google"
           className="w-full md:w-[222px]"
           onClick={() => {
-            setIsSocialLoading(true);
             window.location.href = getGoogleLoginUrl();
           }}
         />
@@ -107,7 +102,6 @@ export const LoginForm = () => {
           provider="kakao"
           className="w-full md:w-[222px]"
           onClick={() => {
-            setIsSocialLoading(true);
             window.location.href = getKakaoLoginUrl();
           }}
         />

--- a/apps/web/src/features/auth/ui/signup-form.tsx
+++ b/apps/web/src/features/auth/ui/signup-form.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { Button, InputField, SocialButton } from "@moum-zip/ui/components";
+import { Button, InputField, LoadingIndicator, SocialButton } from "@moum-zip/ui/components";
 import Link from "next/link";
-import { startTransition, useActionState } from "react";
+import { startTransition, useActionState, useState } from "react";
 import { useForm } from "react-hook-form";
 import { signupAction } from "@/_pages/auth/actions";
 import { getGoogleLoginUrl, getKakaoLoginUrl } from "@/_pages/auth/use-cases/social-login-url";
@@ -24,6 +24,7 @@ const ERROR_MESSAGES = {
 export const SignupForm = () => {
   // 서버 액션 상태 관리
   const [state, formAction, isPending] = useActionState(signupAction, null);
+  const [isSocialLoading, setIsSocialLoading] = useState(false);
 
   const {
     register,
@@ -33,6 +34,9 @@ export const SignupForm = () => {
   } = useForm<SignupFormValues>({
     mode: "onBlur", // 필드 입력 완료 후 넘어갈 때 유효성 검사
   });
+
+  // 소셜 로그인 진행 중일 때 로딩 화면 표시
+  if (isSocialLoading) return <LoadingIndicator fullScreen text="로그인 중" />;
 
   // 유효성 검사 통과 후 → 서버 액션 호출
   const onSubmit = handleSubmit((data) => {
@@ -82,6 +86,10 @@ export const SignupForm = () => {
           registration={register("password", {
             required: "비밀번호를 입력해주세요.",
             minLength: { value: 8, message: "8자 이상 입력해주세요." },
+            pattern: {
+              value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])/,
+              message: "영문, 숫자, 특수문자를 조합해주세요.",
+            },
           })}
           error={errors.password}
         />
@@ -118,6 +126,7 @@ export const SignupForm = () => {
           provider="google"
           className="w-full md:w-[222px]"
           onClick={() => {
+            setIsSocialLoading(true);
             window.location.href = getGoogleLoginUrl();
           }}
         />
@@ -125,6 +134,7 @@ export const SignupForm = () => {
           provider="kakao"
           className="w-full md:w-[222px]"
           onClick={() => {
+            setIsSocialLoading(true);
             window.location.href = getKakaoLoginUrl();
           }}
         />

--- a/apps/web/src/features/auth/ui/signup-form.tsx
+++ b/apps/web/src/features/auth/ui/signup-form.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { Button, InputField, LoadingIndicator, SocialButton } from "@moum-zip/ui/components";
+import { Button, InputField, SocialButton } from "@moum-zip/ui/components";
 import Link from "next/link";
-import { startTransition, useActionState, useState } from "react";
+import { startTransition, useActionState } from "react";
 import { useForm } from "react-hook-form";
 import { signupAction } from "@/_pages/auth/actions";
 import { getGoogleLoginUrl, getKakaoLoginUrl } from "@/_pages/auth/use-cases/social-login-url";
@@ -24,7 +24,6 @@ const ERROR_MESSAGES = {
 export const SignupForm = () => {
   // 서버 액션 상태 관리
   const [state, formAction, isPending] = useActionState(signupAction, null);
-  const [isSocialLoading, setIsSocialLoading] = useState(false);
 
   const {
     register,
@@ -34,9 +33,6 @@ export const SignupForm = () => {
   } = useForm<SignupFormValues>({
     mode: "onBlur", // 필드 입력 완료 후 넘어갈 때 유효성 검사
   });
-
-  // 소셜 로그인 진행 중일 때 로딩 화면 표시
-  if (isSocialLoading) return <LoadingIndicator fullScreen text="로그인 중" />;
 
   // 유효성 검사 통과 후 → 서버 액션 호출
   const onSubmit = handleSubmit((data) => {
@@ -126,7 +122,6 @@ export const SignupForm = () => {
           provider="google"
           className="w-full md:w-[222px]"
           onClick={() => {
-            setIsSocialLoading(true);
             window.location.href = getGoogleLoginUrl();
           }}
         />
@@ -134,7 +129,6 @@ export const SignupForm = () => {
           provider="kakao"
           className="w-full md:w-[222px]"
           onClick={() => {
-            setIsSocialLoading(true);
             window.location.href = getKakaoLoginUrl();
           }}
         />

--- a/apps/web/src/features/auth/ui/signup-form.tsx
+++ b/apps/web/src/features/auth/ui/signup-form.tsx
@@ -83,7 +83,7 @@ export const SignupForm = () => {
             required: "비밀번호를 입력해주세요.",
             minLength: { value: 8, message: "8자 이상 입력해주세요." },
             pattern: {
-              value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])/,
+              value: /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]+$/,
               message: "영문, 숫자, 특수문자를 조합해주세요.",
             },
           })}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -10,7 +10,7 @@ import {
 } from "@/shared/lib/cookies";
 
 // 비로그인 유저도 접근 가능한 공개 경로
-const PUBLIC_PATHS = ["/login", "/signup", "/search", "/oauth", "/moim-detail"];
+const PUBLIC_PATHS = ["/", "/login", "/signup", "/search", "/oauth", "/moim-detail"];
 
 // 미들웨어 실행 건너뛰는 경로
 const EXCLUDED_PATHS = ["/_next", "/api", "/fonts", "/favicon"];


### PR DESCRIPTION
## 📌 Summary
인증 UX 개선 및 라우팅 설정 수정
- close #135

## 📄 Tasks

### 소셜 로그인 콜백 로딩 UI 교체 (`oauth/callback/page.tsx`)
- 기존 텍스트(`로그인 처리 중...`)를 `LoadingIndicator` 컴포넌트로 교체

### 비밀번호 유효성 검사 강화 (`signup-form.tsx`)
- 기존: 8자 이상 길이 검사만 수행 → 한글 입력도 통과되는 문제
- 변경: 영문 + 숫자 + 특수문자 조합 필수 조건 추가
- 로그인 폼은 기존 가입자 호환성을 고려해 길이 검사만 유지

### 공개 경로에 `/` 추가 (`proxy.ts`)
- 배포 링크 최초 접근 시 로그인 페이지로 리다이렉트되는 문제 수정
- 내비게이션 로고 클릭 시 랜딩 페이지로 이동하지 않는 문제 수정
- `PUBLIC_PATHS`에 `/` 추가하여 랜딩 페이지로 정상 진입하도록 변경

### 소셜 로그인 프로필 이미지 도메인 추가 (`next.config.ts`)
- 카카오/구글 프로필 이미지 도메인 미등록으로 런타임 에러 발생
- `remotePatterns`에 `img1.kakaocdn.net`, `t1.kakaocdn.net`, `lh3.googleusercontent.com` 추가

## 👀 To Reviewer
- 비밀번호 유효성 검사 강화는 회원가입 폼에만 적용했습니다. 로그인 폼은 기존 가입자 호환성을 고려해 길이 검사만 유지했습니다.

## 📸 Screenshot

_작업한 내용에 대한 스크린샷을 첨부해주세요._

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 주요 변경 사항

* **개선 사항**
  * OAuth 콜백 페이지의 로딩 표시가 더 일관된 UI로 개선되었습니다.
  * 회원가입 비밀번호 검증이 강화되어 영문·숫자·특수문자 조합을 요구합니다(관련 안내 문구 추가).
  * 홈페이지(/)는 로그인 없이도 접근 가능하도록 변경되었습니다.
  * 외부 CDN(카카오 CDN)에서의 이미지 로딩이 허용되어 일부 원격 이미지가 정상 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->