### PR TITLE
[refactor] 모임 생성·수정 - 이미지 업로드 UX 개선 (업로드 중 상태 처리)

### DIFF
--- a/apps/web/src/features/moim-create/ui/moim-create-form.tsx
+++ b/apps/web/src/features/moim-create/ui/moim-create-form.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { uploadImage } from "@/_pages/moim-create/use-cases/upload-image";
 import { useMoimCreateForm } from "@/features/moim-create/model/use-moim-create-form";
 import { MoimFormFields } from "@/features/moim-create/ui/moim-form-fields";
 
 export const MoimCreateForm = () => {
   const router = useRouter();
+  const [isImageUploading, setIsImageUploading] = useState(false);
   const { form, onSubmit, state, isPending } = useMoimCreateForm();
   const { setError, clearErrors } = form;
 
@@ -19,6 +21,7 @@ export const MoimCreateForm = () => {
       const file = (event.target as HTMLInputElement).files?.[0];
       if (!file) return;
 
+      setIsImageUploading(true);
       try {
         const publicUrl = await uploadImage(file);
         onChange(publicUrl);
@@ -28,6 +31,8 @@ export const MoimCreateForm = () => {
           type: "manual",
           message: "이미지 업로드에 실패했습니다. 다시 시도해주세요.",
         });
+      } finally {
+        setIsImageUploading(false);
       }
     };
 
@@ -40,6 +45,7 @@ export const MoimCreateForm = () => {
       onSubmit={onSubmit}
       state={state}
       isPending={isPending}
+      isImageUploading={isImageUploading}
       submitLabel={isPending ? "생성 중" : "모임 만들기"}
       onCancel={() => router.back()}
       onImageUpload={handleImageUpload}

--- a/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
+++ b/apps/web/src/features/moim-create/ui/moim-form-fields.tsx
@@ -19,6 +19,7 @@ interface MoimFormFieldsProps {
   onSubmit: (event?: React.BaseSyntheticEvent) => void;
   state: MoimFormState | null;
   isPending: boolean;
+  isImageUploading?: boolean;
   submitLabel: string;
   onCancel: () => void;
   onImageUpload: (onChange: (url: string) => void) => Promise<void>;
@@ -29,6 +30,7 @@ export const MoimFormFields = ({
   onSubmit,
   state,
   isPending,
+  isImageUploading = false,
   submitLabel,
   onCancel,
   onImageUpload,
@@ -153,6 +155,8 @@ export const MoimFormFields = ({
                 </p>
 
                 <FileInput
+                  disabled={isPending || isImageUploading}
+                  helperText={isImageUploading ? "업로드 중" : "파일 첨부"}
                   onUploadClick={() => onImageUpload(field.onChange)}
                   previewItems={field.value ? [{ id: "1", imageUrl: field.value }] : []}
                   onPreviewRemove={() => {
@@ -283,7 +287,7 @@ export const MoimFormFields = ({
           variant="primary"
           size="medium"
           className="min-w-0 flex-1 md:w-auto md:max-w-[216px]"
-          disabled={isPending}
+          disabled={isPending || isImageUploading}
         >
           {submitLabel}
         </Button>

--- a/apps/web/src/features/moim-edit/ui/moim-edit-form.tsx
+++ b/apps/web/src/features/moim-edit/ui/moim-edit-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { uploadImage } from "@/_pages/moim-create/use-cases/upload-image";
 import type { MoimCreateFormValues } from "@/features/moim-create/model/schema";
 import { MoimFormFields } from "@/features/moim-create/ui/moim-form-fields";
@@ -13,6 +14,7 @@ interface MoimEditFormProps {
 
 export const MoimEditForm = ({ meetingId, initialValues }: MoimEditFormProps) => {
   const router = useRouter();
+  const [isImageUploading, setIsImageUploading] = useState(false);
   const { form, onSubmit, state, isPending } = useMoimEditForm({
     meetingId,
     initialValues,
@@ -29,6 +31,7 @@ export const MoimEditForm = ({ meetingId, initialValues }: MoimEditFormProps) =>
       const file = (event.target as HTMLInputElement).files?.[0];
       if (!file) return;
 
+      setIsImageUploading(true);
       try {
         const publicUrl = await uploadImage(file);
         onChange(publicUrl);
@@ -38,6 +41,8 @@ export const MoimEditForm = ({ meetingId, initialValues }: MoimEditFormProps) =>
           type: "manual",
           message: "이미지 업로드에 실패했습니다. 다시 시도해주세요.",
         });
+      } finally {
+        setIsImageUploading(false);
       }
     };
 
@@ -50,6 +55,7 @@ export const MoimEditForm = ({ meetingId, initialValues }: MoimEditFormProps) =>
       onSubmit={onSubmit}
       state={state}
       isPending={isPending}
+      isImageUploading={isImageUploading}
       submitLabel={isPending ? "수정 중" : "수정하기"}
       onCancel={() => router.back()}
       onImageUpload={handleImageUpload}


### PR DESCRIPTION
## 📌 Summary

- close #149

## 📄 Tasks

- `MoimCreateForm` / `MoimEditForm`: 이미지 업로드 시 isImageUploading state 추가 (`finally`로 종료 시 상태 해제)
- `MoimFormFields`: isImageUploading prop 추가(기본값 false)
- `FileInput`: 업로드 중 isImageUploading 또는 isPending 시 비활성화, 헬퍼 텍스트 "업로드 중" 표시
- 모임 만들기 / 수정하기 버튼: isPending 또는 isImageUploading일 때 비활성화

## 👀 To Reviewer

- 코드 리팩토링은 다음 PR로 분리할 예정입니다.

## 📸 Screenshot

https://github.com/user-attachments/assets/6d835e8e-b984-4c4d-9e18-181e6e71355d

이미지 업로드 시 
- 파일 첨부 영역 비활성화 및 helperText "업로드 중" 문구 노출
- 제출 버튼 (모임 만들기 / 수정하기) 비활성화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 이미지 업로드 중 상태를 추적하여 더 나은 사용자 경험 제공
  * 이미지 업로드 진행 중 파일 입력 및 제출 버튼 비활성화
  * 이미지 업로드 중 "업로드 중" 안내 텍스트 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->