### PR TITLE
[refactor] 마이페이지 query state 구조 분리

### DIFF
--- a/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
+++ b/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import type { FavoriteList } from "@moum-zip/api";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { getSpaceSlugAction } from "../actions";
+import type { CreatedFilterKey, MypageMoimCard, MypageTabKey } from "../model";
+import { getFavoritesQueryOptions, getJoinedMeetingsQueryOptions } from "../queries";
+import { applyFavoriteState, buildFavoriteMeetingIds, buildLikedMeetings, useToggleFavorite } from "../use-cases";
+import { useCreatedMeetings } from "./use-created-meetings";
+
+type MoimTabKey = Exclude<MypageTabKey, "created">;
+
+interface UseMypageViewStateParams {
+  initialFavoriteList: FavoriteList;
+  moims: Record<MoimTabKey, MypageMoimCard[]>;
+  createdMoims: Record<CreatedFilterKey, MypageMoimCard[]>;
+  enableRemoteFetch: boolean;
+}
+
+const isMypageTabKey = (tab: string): tab is MypageTabKey => {
+  return tab === "joined" || tab === "created" || tab === "liked";
+};
+
+export const useMypageViewState = ({
+  initialFavoriteList,
+  moims,
+  createdMoims,
+  enableRemoteFetch,
+}: UseMypageViewStateParams) => {
+  const router = useRouter();
+  const [selectedTab, setSelectedTab] = useState<MypageTabKey>("joined");
+  const [createdFilter, setCreatedFilter] = useState<CreatedFilterKey>("ongoing");
+  const favoriteMutation = useToggleFavorite(enableRemoteFetch);
+
+  const {
+    data: joinedMeetingCards = moims.joined,
+    isError: isJoinedError,
+    refetch: refetchJoinedMeetings,
+  } = useQuery({
+    ...getJoinedMeetingsQueryOptions(moims.joined),
+    enabled: enableRemoteFetch && selectedTab === "joined",
+  });
+
+  const {
+    data: createdMeetingCards = createdMoims[createdFilter],
+    isError: isCreatedError,
+    refetch: refetchCreatedMeetings,
+  } = useCreatedMeetings(createdFilter, createdMoims[createdFilter], enableRemoteFetch && selectedTab === "created");
+
+  const {
+    data: favoriteList,
+    isError: isLikedError,
+    refetch: refetchLikedMeetings,
+  } = useQuery({
+    ...getFavoritesQueryOptions(initialFavoriteList),
+    enabled: enableRemoteFetch,
+  });
+
+  const favoriteMeetingIds = useMemo(
+    () => buildFavoriteMeetingIds(enableRemoteFetch ? favoriteList : undefined, moims.liked),
+    [enableRemoteFetch, favoriteList, moims.liked],
+  );
+
+  const joinedMeetings = useMemo(
+    () => applyFavoriteState(joinedMeetingCards, favoriteMeetingIds),
+    [favoriteMeetingIds, joinedMeetingCards],
+  );
+
+  const createdMeetings = useMemo(
+    () => applyFavoriteState(createdMeetingCards, favoriteMeetingIds),
+    [createdMeetingCards, favoriteMeetingIds],
+  );
+
+  const likedMeetings = useMemo(
+    () => buildLikedMeetings(enableRemoteFetch ? favoriteList : undefined, moims.liked, enableRemoteFetch),
+    [enableRemoteFetch, favoriteList, moims.liked],
+  );
+
+  const handleTabChange = (tab: string) => {
+    if (!isMypageTabKey(tab)) {
+      return;
+    }
+
+    setSelectedTab(tab);
+  };
+
+  const findMeetingById = (meetingId: string) => {
+    return (
+      joinedMeetings.find((meeting) => meeting.id === meetingId) ??
+      createdMeetings.find((meeting) => meeting.id === meetingId) ??
+      likedMeetings.find((meeting) => meeting.id === meetingId)
+    );
+  };
+
+  const handleToggleLike = (meetingId: string) => {
+    if (!enableRemoteFetch) {
+      return;
+    }
+
+    const meeting = findMeetingById(meetingId);
+
+    if (!meeting) {
+      return;
+    }
+
+    favoriteMutation.mutate({
+      meetingId: Number(meetingId),
+      nextLiked: !meeting.liked,
+    });
+  };
+
+  const handleEnterSpace = async (meetingId: string) => {
+    const result = await getSpaceSlugAction(Number(meetingId));
+
+    if (!result.ok) {
+      return;
+    }
+
+    router.push(`/${result.slug}`);
+  };
+
+  return {
+    selectedTab,
+    createdFilter,
+    joinedMeetings,
+    createdMeetings,
+    likedMeetings,
+    isJoinedError,
+    isCreatedError,
+    isLikedError,
+    handleTabChange,
+    handleToggleLike,
+    handleEnterSpace,
+    refetchJoinedMeetings,
+    refetchCreatedMeetings,
+    refetchLikedMeetings,
+    setCreatedFilter,
+  };
+};

--- a/apps/web/src/_pages/mypage/ui/mypage-view.tsx
+++ b/apps/web/src/_pages/mypage/ui/mypage-view.tsx
@@ -1,16 +1,10 @@
 "use client";
 
 import type { FavoriteList } from "@moum-zip/api";
-import { useQuery } from "@tanstack/react-query";
 import { Tabs } from "@ui/components";
 import { cn } from "@ui/lib/utils";
-import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
-import { getSpaceSlugAction } from "../actions";
-import { useCreatedMeetings } from "../hooks/use-created-meetings";
+import { useMypageViewState } from "../hooks/use-mypage-view-state";
 import type { CreatedFilterKey, MypageMoimCard, MypageProfile, MypageTabKey } from "../model";
-import { getFavoritesQueryOptions, getJoinedMeetingsQueryOptions } from "../queries";
-import { applyFavoriteState, buildFavoriteMeetingIds, buildLikedMeetings, useToggleFavorite } from "../use-cases";
 import MoimCardList from "./moim-card-list";
 import ProfileSection from "./profile-section";
 
@@ -38,88 +32,27 @@ export default function MypageView({
   createdMoims,
   enableRemoteFetch = true,
 }: MypagePageProps) {
-  const router = useRouter();
-  const [selectedTab, setSelectedTab] = useState<MypageTabKey>("joined");
-  const [createdFilter, setCreatedFilter] = useState<CreatedFilterKey>("ongoing");
-  const favoriteMutation = useToggleFavorite(enableRemoteFetch);
-
   const {
-    data: joinedMeetingCards = moims.joined,
-    isError: isJoinedError,
-    refetch: refetchJoinedMeetings,
-  } = useQuery({
-    ...getJoinedMeetingsQueryOptions(moims.joined),
-    enabled: enableRemoteFetch && selectedTab === "joined",
+    createdFilter,
+    joinedMeetings,
+    createdMeetings,
+    likedMeetings,
+    isJoinedError,
+    isCreatedError,
+    isLikedError,
+    handleTabChange,
+    handleToggleLike,
+    handleEnterSpace,
+    refetchJoinedMeetings,
+    refetchCreatedMeetings,
+    refetchLikedMeetings,
+    setCreatedFilter,
+  } = useMypageViewState({
+    initialFavoriteList,
+    moims,
+    createdMoims,
+    enableRemoteFetch,
   });
-
-  const {
-    data: createdMeetingCards = createdMoims[createdFilter],
-    isError: isCreatedError,
-    refetch: refetchCreatedMeetings,
-  } = useCreatedMeetings(createdFilter, createdMoims[createdFilter], enableRemoteFetch && selectedTab === "created");
-
-  const {
-    data: favoriteList,
-    isError: isLikedError,
-    refetch: refetchLikedMeetings,
-  } = useQuery({
-    ...getFavoritesQueryOptions(initialFavoriteList),
-    enabled: enableRemoteFetch,
-  });
-
-  const favoriteMeetingIds = useMemo(
-    () => buildFavoriteMeetingIds(enableRemoteFetch ? favoriteList : undefined, moims.liked),
-    [enableRemoteFetch, favoriteList, moims.liked],
-  );
-
-  const joinedMeetings = useMemo(
-    () => applyFavoriteState(joinedMeetingCards, favoriteMeetingIds),
-    [favoriteMeetingIds, joinedMeetingCards],
-  );
-  const createdMeetings = useMemo(
-    () => applyFavoriteState(createdMeetingCards, favoriteMeetingIds),
-    [createdMeetingCards, favoriteMeetingIds],
-  );
-  const likedMeetings = useMemo(
-    () => buildLikedMeetings(enableRemoteFetch ? favoriteList : undefined, moims.liked, enableRemoteFetch),
-    [enableRemoteFetch, favoriteList, moims.liked],
-  );
-
-  const findMeetingById = (meetingId: string) => {
-    return (
-      joinedMeetings.find((meeting) => meeting.id === meetingId) ??
-      createdMeetings.find((meeting) => meeting.id === meetingId) ??
-      likedMeetings.find((meeting) => meeting.id === meetingId)
-    );
-  };
-
-  const handleToggleLike = (meetingId: string) => {
-    if (!enableRemoteFetch) {
-      return;
-    }
-
-    const meeting = findMeetingById(meetingId);
-
-    if (!meeting) {
-      return;
-    }
-
-    favoriteMutation.mutate({
-      meetingId: Number(meetingId),
-      nextLiked: !meeting.liked,
-    });
-  };
-
-  const handleEnterSpace = async (meetingId: string) => {
-    // 클릭 시 meetingId에 연결된 space slug를 찾아 스페이스 메인으로 이동합니다.
-    const result = await getSpaceSlugAction(Number(meetingId));
-
-    if (!result.ok) {
-      return;
-    }
-
-    router.push(`/${result.slug}`);
-  };
 
   return (
     <main className="no-scrollbar h-dvh overflow-y-auto bg-background-secondary px-4 py-8 text-foreground md:px-9 md:py-10 lg:px-8">
@@ -132,12 +65,7 @@ export default function MypageView({
             </div>
           </div>
 
-          <Tabs
-            defaultTab="joined"
-            size="large"
-            className="w-full min-w-0"
-            onTabChange={(tab) => setSelectedTab(tab as MypageTabKey)}
-          >
+          <Tabs defaultTab="joined" size="large" className="w-full min-w-0" onTabChange={handleTabChange}>
             <Tabs.List className="no-scrollbar w-full min-w-0 overflow-x-auto">
               {tabs.map((tab) => (
                 <Tabs.Trigger


### PR DESCRIPTION
## 📌 Summary

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- close #154 
- 마이페이지 뷰 컴포넌트에 집중되어 있던 query/state/handler 로직을 분리해, 화면 렌더링과 상태 관리 책임을 나눴습니다.
- 탭별 데이터 조회 흐름과 좋아요/스페이스 이동 핸들러를 별도 hook으로 모아 마이페이지 코드 가독성과 유지보수성을 개선했습니다.

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- `mypage-view.tsx`에 있던 탭 상태, 쿼리 호출, 파생 데이터 계산, 이벤트 핸들러 로직을 `use-mypage-view-state.ts`로 분리했습니다.
- `joined`, `created`, `liked` 탭의 데이터 조회 및 에러 상태 관리 흐름을 hook 내부로 모았습니다.
- 좋아요 토글과 스페이스 이동 처리 로직을 hook에서 관리하도록 정리했습니다.
- `mypage-view.tsx`는 렌더링 중심으로 정리해 화면 구조를 더 읽기 쉽게 만들었습니다.

## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

- 이번 PR은 기능 변경보다 `query/state 구조 분리`에 초점을 둔 리팩토링입니다.
- 마이페이지 뷰에서 상태/데이터 흐름을 hook으로 옮긴 방향이 적절한지 중점적으로 봐주시면 좋겠습니다.
- export 방식, 네이밍, biome warning 정리는 다음 이슈에서 분리해서 진행할 예정이라 이번 PR에서는 포함하지 않았습니다.
- 탭 전환, created 필터 전환, 좋아요 토글, 스페이스 이동 흐름에서 구조 분리가 과하지 않은지도 함께 봐주시면 감사하겠습니다.

## 📸 Screenshot

_작업한 내용에 대한 스크린샷을 첨부해주세요._

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * "My Page" 뷰의 상태 관리 로직을 새로운 훅으로 통합하여 코드 구조를 개선했습니다. 탭 선택(가입됨, 생성됨, 좋아요), 필터링, 데이터 페칭 및 사용자 상호작용 처리가 이제 중앙집중식으로 관리되어 코드 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->