### PR TITLE
[fix] 스페이스 찾기 페이지 필터 네이밍/ 모집마감 시 버튼 비활성화 처리

### DIFF
--- a/apps/web/src/app/(main)/search/page.tsx
+++ b/apps/web/src/app/(main)/search/page.tsx
@@ -54,7 +54,7 @@ export default async function SpacePage({ searchParams }: SpacePageProps) {
 
   return (
     <div className="min-h-screen">
-      <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 pt-6 pb-24 sm:px-6 lg:max-w-6xl lg:gap-8 lg:pt-[1.6875rem] 2xl:max-w-7xl">
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 pt-6 pb-24 sm:px-6 lg:max-w-6xl lg:gap-8 lg:pt-6.75 2xl:max-w-7xl">
         <SpaceSearchHero />
         <HydrationBoundary state={dehydrate(queryClient)}>
           <SpaceSearchContentSection
@@ -74,7 +74,7 @@ export default async function SpacePage({ searchParams }: SpacePageProps) {
             variant="icon"
           />
           <SpaceSearchCreateButton
-            className="pointer-events-auto hidden sm:inline-flex lg:h-14 lg:min-w-[172px] lg:px-5 lg:text-lg 2xl:h-16 2xl:min-w-[188px] 2xl:px-6 2xl:text-xl"
+            className="pointer-events-auto hidden sm:inline-flex lg:h-14 lg:min-w-43 lg:px-5 lg:text-lg 2xl:h-16 2xl:min-w-47 2xl:px-6 2xl:text-xl"
             isAuthenticated={isAuthenticatedRequest}
           >
             스페이스 만들기

--- a/apps/web/src/features/space-search/model/constants.ts
+++ b/apps/web/src/features/space-search/model/constants.ts
@@ -13,16 +13,16 @@ export const SPACE_SEARCH_CATEGORIES: SpaceSearchCategory[] = [
 export const SPACE_SEARCH_FILTERS: SpaceSearchFilter[] = [
   {
     id: "date",
-    label: "날짜 전체",
+    label: "최신/오래된 순",
     options: [
-      { id: "default", label: "날짜 전체" },
+      { id: "default", label: "최신/오래된 순" },
       { id: "latest", label: "최신 순" },
       { id: "oldest", label: "오래된 순" },
     ],
   },
   {
     id: "location",
-    label: "지역 전체",
+    label: "온/오프라인",
     options: [
       { id: "all", label: "온/오프라인" },
       { id: "online", label: "온라인" },
@@ -31,9 +31,9 @@ export const SPACE_SEARCH_FILTERS: SpaceSearchFilter[] = [
   },
   {
     id: "deadline",
-    label: "마감 임박",
+    label: "마감 빠른/느린 순",
     options: [
-      { id: "default", label: "마감 임박" },
+      { id: "default", label: "마감 빠른/느린 순" },
       { id: "fast", label: "마감 빠른 순" },
       { id: "slow", label: "마감 느린 순" },
     ],

--- a/apps/web/src/features/space-search/model/result-mappers.ts
+++ b/apps/web/src/features/space-search/model/result-mappers.ts
@@ -51,6 +51,14 @@ const formatDeadlineLabel = (registrationEnd: string | null) => {
   return `${remainingDays}일 후 마감`;
 };
 
+const isRegistClosed = (registrationEnd: string | null) => {
+  if (!registrationEnd) {
+    return false;
+  }
+
+  return new Date(registrationEnd).getTime() <= Date.now();
+};
+
 export const mapSearchResultItemToSpaceCardItem = (item: SearchResultItem): SpaceCardItem => {
   return {
     category: categoryLabelById[item.type] ?? item.type,
@@ -61,6 +69,7 @@ export const mapSearchResultItemToSpaceCardItem = (item: SearchResultItem): Spac
     id: item.id,
     imageAlt: `${item.title} thumbnail`,
     imageSrc: item.image ?? FALLBACK_SPACE_IMAGE,
+    isRegistClosed: isRegistClosed(item.registrationEnd),
     isLiked: item.isLiked,
     maxParticipants: item.capacity,
     metaChips: [

--- a/apps/web/src/features/space-search/model/result-mappers.ts
+++ b/apps/web/src/features/space-search/model/result-mappers.ts
@@ -12,6 +12,7 @@ const KST_TIME_ZONE = "Asia/Seoul";
 const dateFormatter = new Intl.DateTimeFormat("ko-KR", {
   day: "numeric",
   month: "numeric",
+  timeZone: KST_TIME_ZONE,
 });
 
 const timeFormatter = new Intl.DateTimeFormat("ko-KR", {

--- a/apps/web/src/features/space-search/model/result-mappers.ts
+++ b/apps/web/src/features/space-search/model/result-mappers.ts
@@ -7,6 +7,8 @@ const FALLBACK_SPACE_IMAGE = `data:image/svg+xml;charset=UTF-8,${encodeURICompon
   '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="640" viewBox="0 0 640 640" fill="none"><rect width="640" height="640" rx="48" fill="#F2F4F7"/><path d="M188 420V220H452V420H188Z" fill="#D0D5DD"/><circle cx="262" cy="276" r="36" fill="#98A2B3"/><path d="M224 388L306 306L368 368L410 326L452 388H224Z" fill="#98A2B3"/></svg>',
 )}`;
 
+const KST_TIME_ZONE = "Asia/Seoul";
+
 const dateFormatter = new Intl.DateTimeFormat("ko-KR", {
   day: "numeric",
   month: "numeric",
@@ -16,6 +18,14 @@ const timeFormatter = new Intl.DateTimeFormat("ko-KR", {
   hour: "2-digit",
   hour12: false,
   minute: "2-digit",
+  timeZone: KST_TIME_ZONE,
+});
+
+const kstDateFormatter = new Intl.DateTimeFormat("ko-KR", {
+  day: "numeric",
+  month: "numeric",
+  timeZone: KST_TIME_ZONE,
+  year: "numeric",
 });
 
 const categoryLabelById = Object.fromEntries(
@@ -30,46 +40,72 @@ const formatChipLabel = (dateTime: string | null, formatter: Intl.DateTimeFormat
   return formatter.format(new Date(dateTime));
 };
 
-const formatDeadlineLabel = (registrationEnd: string | null) => {
+const toDeadlineTime = (registrationEnd: string | null) => {
   if (!registrationEnd) {
-    return "상시 모집";
+    return null;
   }
 
-  const deadlineTime = new Date(registrationEnd).getTime();
-  const remainingTime = deadlineTime - Date.now();
+  const deadlineTime = Date.parse(registrationEnd);
+
+  if (Number.isNaN(deadlineTime)) {
+    return null;
+  }
+
+  return deadlineTime;
+};
+
+const isSameDayInKst = (a: number, b: number) => {
+  return kstDateFormatter.format(new Date(a)) === kstDateFormatter.format(new Date(b));
+};
+
+const getDeadlineMeta = (registrationEnd: string | null, now: number) => {
+  const deadlineTime = toDeadlineTime(registrationEnd);
+
+  if (deadlineTime === null) {
+    return {
+      deadlineLabel: "상시 모집",
+      isRegistClosed: false,
+    };
+  }
+
+  const remainingTime = deadlineTime - now;
 
   if (remainingTime <= 0) {
-    return "마감";
+    return {
+      deadlineLabel: "마감",
+      isRegistClosed: true,
+    };
+  }
+
+  if (isSameDayInKst(now, deadlineTime)) {
+    return {
+      deadlineLabel: `오늘 ${timeFormatter.format(new Date(deadlineTime))} 마감`,
+      isRegistClosed: false,
+    };
   }
 
   const remainingDays = Math.ceil(remainingTime / (1000 * 60 * 60 * 24));
 
-  if (remainingDays <= 1) {
-    return "오늘 마감";
-  }
-
-  return `${remainingDays}일 후 마감`;
-};
-
-const isRegistClosed = (registrationEnd: string | null) => {
-  if (!registrationEnd) {
-    return false;
-  }
-
-  return new Date(registrationEnd).getTime() <= Date.now();
+  return {
+    deadlineLabel: `${remainingDays}일 후 마감`,
+    isRegistClosed: false,
+  };
 };
 
 export const mapSearchResultItemToSpaceCardItem = (item: SearchResultItem): SpaceCardItem => {
+  const now = Date.now();
+  const { deadlineLabel, isRegistClosed } = getDeadlineMeta(item.registrationEnd, now);
+
   return {
     category: categoryLabelById[item.type] ?? item.type,
     categoryId: item.type,
     currentParticipants: item.participantCount,
-    deadlineLabel: formatDeadlineLabel(item.registrationEnd),
+    deadlineLabel,
     district: item.location,
     id: item.id,
     imageAlt: `${item.title} thumbnail`,
     imageSrc: item.image ?? FALLBACK_SPACE_IMAGE,
-    isRegistClosed: isRegistClosed(item.registrationEnd),
+    isRegistClosed,
     isLiked: item.isLiked,
     maxParticipants: item.capacity,
     metaChips: [

--- a/apps/web/src/features/space-search/model/types.ts
+++ b/apps/web/src/features/space-search/model/types.ts
@@ -45,6 +45,7 @@ export interface SpaceCardItem {
   id: string;
   imageAlt: string;
   imageSrc: string;
+  isRegistClosed: boolean;
   isLiked?: boolean;
   maxParticipants: number;
   metaChips: SpaceCardMetaChip[];

--- a/apps/web/src/features/space-search/ui/space-card.tsx
+++ b/apps/web/src/features/space-search/ui/space-card.tsx
@@ -62,7 +62,7 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
 
   const joinButtonClassName = cn(
     "h-12 min-w-26 shrink-0 rounded-xl px-6 font-semibold text-base leading-6 tracking-[-0.02em] lg:h-11 lg:min-w-24 lg:px-5 lg:text-sm 2xl:h-12 2xl:min-w-26 2xl:px-6 2xl:text-base",
-    isRegistClosed ? "cursor-not-allowed opacity-60 active:scale-100" : "border-[1.5px]",
+    isRegistClosed ? "cursor-not-allowed opacity-60 active:scale-100" : "border-[0.09375rem]",
     "w-auto",
   );
 

--- a/apps/web/src/features/space-search/ui/space-card.tsx
+++ b/apps/web/src/features/space-search/ui/space-card.tsx
@@ -1,6 +1,8 @@
 import { CheckCircleIcon, LabeledProgressBar, Tag } from "@ui/components";
 import Image from "next/image";
+
 import { cn } from "@/shared/lib/cn";
+
 import LocationPinIcon from "../assets/location-pin.svg";
 import type { SpaceCardItem, SpaceCardMetaChip } from "../model/types";
 import { SpaceCardJoinButton } from "./space-card-join-button";
@@ -47,15 +49,22 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
     currentParticipants,
     deadlineLabel,
     district,
+    id: meetingId,
     imageAlt,
     imageSrc,
     isLiked = false,
+    isRegistClosed,
     maxParticipants,
     metaChips,
     status,
     title,
-    id: meetingId,
   } = item;
+
+  const joinButtonClassName = cn(
+    "h-12 min-w-26 shrink-0 rounded-xl px-6 font-semibold text-base leading-6 tracking-[-0.02em] lg:h-11 lg:min-w-24 lg:px-5 lg:text-sm 2xl:h-12 2xl:min-w-26 2xl:px-6 2xl:text-base",
+    isRegistClosed ? "cursor-not-allowed opacity-60 active:scale-100" : "border-[1.5px]",
+    "w-auto",
+  );
 
   return (
     <article className="flex flex-col gap-0 overflow-hidden rounded-[2rem] bg-card shadow-[0_20px_50px_rgba(17,17,17,0.04)] sm:gap-6 sm:overflow-visible sm:p-6 md:flex-row md:items-center lg:gap-5 lg:p-5 2xl:gap-6 2xl:p-6">
@@ -69,7 +78,7 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
           width={340}
         />
         <div className="absolute top-4 right-4 sm:hidden">
-          <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={item.id} />
+          <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={meetingId} />
         </div>
       </div>
 
@@ -91,7 +100,7 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
           </div>
 
           <div className="hidden sm:block">
-            <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={item.id} />
+            <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={meetingId} />
           </div>
         </div>
 
@@ -116,17 +125,14 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
           </div>
 
           <SpaceCardJoinButton
-            className={cn(
-              "h-12 min-w-26 shrink-0 rounded-xl border-[1.5px] px-6 font-semibold text-base leading-6 tracking-[-0.02em]",
-              "lg:h-11 lg:min-w-24 lg:px-5 lg:text-sm 2xl:h-12 2xl:min-w-26 2xl:px-6 2xl:text-base",
-              "w-auto",
-            )}
+            className={joinButtonClassName}
+            disabled={isRegistClosed}
             size="small"
-            variant="secondary"
+            variant={isRegistClosed ? "primary" : "secondary"}
             isAuthenticated={isAuthenticated}
             meetingId={meetingId}
           >
-            참여하기
+            {isRegistClosed ? "모집 마감" : "참여하기"}
           </SpaceCardJoinButton>
         </div>
       </div>

--- a/apps/web/src/features/space-search/ui/space-card.tsx
+++ b/apps/web/src/features/space-search/ui/space-card.tsx
@@ -70,9 +70,11 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
   const displayTitle = truncateTitle(title);
 
   const joinButtonClassName = cn(
-    "h-12 min-w-26 shrink-0 rounded-xl px-6 font-semibold text-base leading-6 tracking-[-0.02em] lg:h-11 lg:min-w-24 lg:px-5 lg:text-sm 2xl:h-12 2xl:min-w-26 2xl:px-6 2xl:text-base",
-    isRegistClosed ? "cursor-not-allowed opacity-60 active:scale-100" : "border-[0.09375rem]",
-    "w-auto",
+    "h-12 min-w-26 shrink-0 whitespace-nowrap px-6 text-base leading-6 tracking-[-0.02em] lg:h-11 lg:min-w-24 lg:px-5 lg:text-sm 2xl:h-12 2xl:min-w-26 2xl:px-6 2xl:text-base",
+    {
+      "border-[0.09375rem]": !isRegistClosed,
+      "cursor-not-allowed opacity-60 active:scale-100": isRegistClosed,
+    },
   );
 
   return (

--- a/apps/web/src/features/space-search/ui/space-card.tsx
+++ b/apps/web/src/features/space-search/ui/space-card.tsx
@@ -17,6 +17,14 @@ interface MetaChipProps {
   chip: SpaceCardMetaChip;
 }
 
+const truncateTitle = (title: string, maxLength = 30) => {
+  if (title.length <= maxLength) {
+    return title;
+  }
+
+  return `${title.slice(0, maxLength)}...`;
+};
+
 const deadlineTagClassName = cn(
   "shrink-0",
   "lg:min-h-[1.375rem] lg:gap-[0.125rem] lg:py-[0.125rem] lg:pr-[0.4375rem] lg:pl-[0.3125rem]",
@@ -34,9 +42,9 @@ const MetaChip = ({ chip }: MetaChipProps) => {
   );
 };
 
-const SpaceCardStatus = ({ label }: { label: string }) => {
+const SpaceCardStatus = ({ className, label }: { className?: string; label: string }) => {
   return (
-    <span className="inline-flex items-center gap-0.5">
+    <span className={cn("inline-flex items-center gap-0.5", className)}>
       <CheckCircleIcon />
       <span className="font-medium text-primary text-sm leading-5">{label}</span>
     </span>
@@ -59,6 +67,7 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
     status,
     title,
   } = item;
+  const displayTitle = truncateTitle(title);
 
   const joinButtonClassName = cn(
     "h-12 min-w-26 shrink-0 rounded-xl px-6 font-semibold text-base leading-6 tracking-[-0.02em] lg:h-11 lg:min-w-24 lg:px-5 lg:text-sm 2xl:h-12 2xl:min-w-26 2xl:px-6 2xl:text-base",
@@ -67,7 +76,7 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
   );
 
   return (
-    <article className="flex flex-col gap-0 overflow-hidden rounded-[2rem] bg-card shadow-[0_20px_50px_rgba(17,17,17,0.04)] sm:gap-6 sm:overflow-visible sm:p-6 md:flex-row md:items-center lg:gap-5 lg:p-5 2xl:gap-6 2xl:p-6">
+    <article className="flex w-full min-w-0 flex-col gap-0 overflow-hidden rounded-[2rem] bg-card shadow-[0_20px_50px_rgba(17,17,17,0.04)] sm:gap-6 sm:overflow-visible sm:p-6 md:flex-row md:items-center lg:gap-5 lg:p-5 2xl:gap-6 2xl:p-6">
       <div className="relative w-full shrink-0 sm:w-full md:w-auto">
         <Image
           alt={imageAlt}
@@ -85,11 +94,14 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
       <div className="flex min-w-0 flex-1 flex-col gap-5 p-4 sm:p-0">
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-              <h2 className="truncate font-semibold text-foreground text-xl leading-normal tracking-[-0.04em]">
-                {title}
+            <div className="flex min-w-0 items-center gap-2">
+              <h2
+                className="min-w-0 flex-1 truncate font-semibold text-foreground text-xl leading-normal tracking-[-0.04em]"
+                title={title}
+              >
+                {displayTitle}
               </h2>
-              {status ? <SpaceCardStatus label={status.label} /> : null}
+              {status ? <SpaceCardStatus className="shrink-0" label={status.label} /> : null}
             </div>
             <p className="mt-1.5 inline-flex items-center gap-1 font-medium text-muted-foreground text-sm leading-5 tracking-[-0.02em]">
               <LocationPinIcon aria-hidden="true" className="size-4 shrink-0" />


### PR DESCRIPTION
## 📌 Summary

- `/search` 페이지의 필터 라벨을 더 직관적으로 정리했습니다.
- 모집 마감 상태일 때 검색 카드의 버튼이 비활성화되도록 처리했습니다.
- 스페이스의 긴 제목이 특정 구간에서 카드 레이아웃을 밀지 않도록 보정했습니다.
- 마감 라벨 표시를 더 구체적으로 개선했습니다.
- close #151 

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- `constants.ts`에서 `/search` 필터 라벨을 더 의미가 잘 드러나도록 정리했습니다.
  - 날짜 전체->최신/오래된 순,
  - 마감 임박->마감 빠른/느린 순
- 검색 카드 데이터 매핑 시 `registrationEnd` 필드를 기준으로 모집 마감 여부를 계산하도록 추가했습니다.
- 모집 마감 상태인 경우 기존 `참여하기` 버튼을 비활성화하고, 버튼 라벨을 `모집 마감`으로 변경했습니다.
- 마감 당일에 마감 라벨이 `오늘 HH:MM 마감` 형태로 더 구체적으로 노출되도록 개선했습니다.
- 검색 카드에서 제목이 긴 경우 태블릿 구간에서 레이아웃이 밀리지 않도록 폭을 보정하고, 30자 초과 시 `...` 처리되도록 `truncate` 처리 했습니다.
## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

- 필터 라벨이 기존보다 더 직관적으로 읽히는지 확인 부탁드립니다.
- 모집 마감 기준은 외부 API GET /meetings 응답 중 `registrationEnd`필드 기반으로 처리했습니다.


## 📸 Screenshot


- 기존
<img width="372" height="82" alt="image" src="https://github.com/user-attachments/assets/f4daa4d3-3d8e-46d2-a449-7fac12a900ca" />

- 변경 후
<img width="357" height="61" alt="image" src="https://github.com/user-attachments/assets/d667a552-c42b-4674-ba29-e29f59cf3cad" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모집 마감 상태 표시 및 관리: 마감 시 "모집 마감" 표기, 참여 버튼 비활성화 및 스타일 변경
  * 모집 마감 문구 개선: 상시 모집/마감/오늘 HH:mm 마감/n일 후 마감 등 KST 기준으로 표기

* **스타일**
  * 검색 필터 라벨 문구 업데이트(날짜·지역·마감)
  * 페이지 레이아웃 상단 여백 및 인증된 생성 버튼 너비 조정
  * 카드 제목 축약 표시(전체 제목은 툴팁으로 유지)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->