### PR TITLE
[refactor] mypage improt/export 구조 정리

### DIFF
--- a/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
+++ b/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
@@ -4,11 +4,16 @@ import type { FavoriteList } from "@moum-zip/api";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
-import { getSpaceSlugAction } from "../actions";
-import type { CreatedFilterKey, MypageMoimCard, MypageTabKey } from "../model";
-import { getFavoritesQueryOptions, getJoinedMeetingsQueryOptions } from "../queries";
-import { applyFavoriteState, buildFavoriteMeetingIds, buildLikedMeetings, useToggleFavorite } from "../use-cases";
-import { useCreatedMeetings } from "./use-created-meetings";
+import { getSpaceSlugAction } from "@/_pages/mypage/actions";
+import { useCreatedMeetings } from "@/_pages/mypage/hooks/use-created-meetings";
+import type { CreatedFilterKey, MypageMoimCard, MypageTabKey } from "@/_pages/mypage/model";
+import { getFavoritesQueryOptions, getJoinedMeetingsQueryOptions } from "@/_pages/mypage/queries";
+import {
+  applyFavoriteState,
+  buildFavoriteMeetingIds,
+  buildLikedMeetings,
+  useToggleFavorite,
+} from "@/_pages/mypage/use-cases";
 
 type MoimTabKey = Exclude<MypageTabKey, "created">;
 

--- a/apps/web/src/_pages/mypage/index.ts
+++ b/apps/web/src/_pages/mypage/index.ts
@@ -1,4 +1,4 @@
 export { mypageTabs } from "./mock-data";
 export type { MypageMoimCard } from "./model";
-export { default } from "./ui/mypage-view";
+export { MypageView } from "./ui/mypage-view";
 export { getMypagePageData } from "./use-cases";

--- a/apps/web/src/_pages/mypage/index.ts
+++ b/apps/web/src/_pages/mypage/index.ts
@@ -1,4 +1,4 @@
 export { mypageTabs } from "./mock-data";
 export type { MypageMoimCard } from "./model";
-export { MypageView } from "./ui/mypage-view";
+export { MypageView } from "./ui";
 export { getMypagePageData } from "./use-cases";

--- a/apps/web/src/_pages/mypage/ui/index.ts
+++ b/apps/web/src/_pages/mypage/ui/index.ts
@@ -1,4 +1,4 @@
-export { default as MoimCard } from "./moim-card";
-export { default as MoimCardList } from "./moim-card-list";
-export { default as MypageView } from "./mypage-view";
-export { default as ProfileSection } from "./profile-section";
+export { MoimCard } from "./moim-card";
+export { MoimCardList } from "./moim-card-list";
+export { MypageView } from "./mypage-view";
+export { ProfileSection } from "./profile-section";

--- a/apps/web/src/_pages/mypage/ui/moim-card-list.tsx
+++ b/apps/web/src/_pages/mypage/ui/moim-card-list.tsx
@@ -1,7 +1,7 @@
 import { Button, Empty } from "@ui/components";
 import type { ReactNode } from "react";
-import type { MypageMoimCard } from "../model/types";
-import MoimCard from "./moim-card";
+import type { MypageMoimCard } from "@/_pages/mypage/model/types";
+import { MoimCard } from "@/_pages/mypage/ui/moim-card";
 
 interface MoimCardListProps {
   moims: MypageMoimCard[];
@@ -20,7 +20,7 @@ const ListStatusContainer = ({ children }: { children: ReactNode }) => {
   );
 };
 
-const MoimCardList = ({
+export const MoimCardList = ({
   moims,
   emptyLabel = "아직 신청한 모임이 없어요",
   isError = false,
@@ -66,5 +66,3 @@ const MoimCardList = ({
     </ListStatusContainer>
   );
 };
-
-export default MoimCardList;

--- a/apps/web/src/_pages/mypage/ui/moim-card.tsx
+++ b/apps/web/src/_pages/mypage/ui/moim-card.tsx
@@ -76,7 +76,7 @@ const MoimPreview = ({ imageTone, imageUrl, className }: MoimPreviewProps) => {
   );
 };
 
-const MoimCard = ({ moim, onToggleLike, onEnterSpace }: MoimCardProps) => {
+export const MoimCard = ({ moim, onToggleLike, onEnterSpace }: MoimCardProps) => {
   const actionVariant = moim.actionVariant === "primary" ? "primary" : "secondary";
 
   const handleToggleLike = () => {
@@ -151,5 +151,3 @@ const MoimCard = ({ moim, onToggleLike, onEnterSpace }: MoimCardProps) => {
     </article>
   );
 };
-
-export default MoimCard;

--- a/apps/web/src/_pages/mypage/ui/mypage-view.tsx
+++ b/apps/web/src/_pages/mypage/ui/mypage-view.tsx
@@ -3,10 +3,10 @@
 import type { FavoriteList } from "@moum-zip/api";
 import { Tabs } from "@ui/components";
 import { cn } from "@ui/lib/utils";
-import { useMypageViewState } from "../hooks/use-mypage-view-state";
-import type { CreatedFilterKey, MypageMoimCard, MypageProfile, MypageTabKey } from "../model";
-import MoimCardList from "./moim-card-list";
-import ProfileSection from "./profile-section";
+import { useMypageViewState } from "@/_pages/mypage/hooks/use-mypage-view-state";
+import type { CreatedFilterKey, MypageMoimCard, MypageProfile, MypageTabKey } from "@/_pages/mypage/model";
+import { MoimCardList } from "@/_pages/mypage/ui/moim-card-list";
+import { ProfileSection } from "@/_pages/mypage/ui/profile-section";
 
 type MoimTabKey = Exclude<MypageTabKey, "created">;
 
@@ -24,7 +24,7 @@ interface MypagePageProps {
   enableRemoteFetch?: boolean;
 }
 
-export default function MypageView({
+export function MypageView({
   initialFavoriteList,
   profile,
   tabs,

--- a/apps/web/src/_pages/mypage/ui/profile-avatar.tsx
+++ b/apps/web/src/_pages/mypage/ui/profile-avatar.tsx
@@ -11,7 +11,7 @@ interface ProfileAvatarProps {
   alt?: string;
 }
 
-export default function ProfileAvatar({ className, iconClassName, src, alt = "프로필 이미지" }: ProfileAvatarProps) {
+export function ProfileAvatar({ className, iconClassName, src, alt = "프로필 이미지" }: ProfileAvatarProps) {
   if (src) {
     return (
       <div

--- a/apps/web/src/_pages/mypage/ui/profile-edit-modal.tsx
+++ b/apps/web/src/_pages/mypage/ui/profile-edit-modal.tsx
@@ -6,8 +6,8 @@ import { Pencil } from "@ui/icons";
 import { cn } from "@ui/lib/utils";
 import { type ChangeEvent, startTransition, useActionState, useEffect, useId, useRef, useState } from "react";
 import { updateProfileAction } from "@/_pages/mypage/actions";
-import type { MypageProfile } from "../model/types";
-import ProfileAvatar from "./profile-avatar";
+import type { MypageProfile } from "@/_pages/mypage/model/types";
+import { ProfileAvatar } from "@/_pages/mypage/ui/profile-avatar";
 
 interface ProfileEditModalProps {
   isOpen: boolean;
@@ -24,7 +24,7 @@ const ERROR_MESSAGES = {
 
 const ALLOWED_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "image/gif"]);
 
-export default function ProfileEditModal({ isOpen, onClose, profile }: ProfileEditModalProps) {
+export function ProfileEditModal({ isOpen, onClose, profile }: ProfileEditModalProps) {
   const nameInputId = useId();
   const emailInputId = useId();
   const titleId = useId();

--- a/apps/web/src/_pages/mypage/ui/profile-section.tsx
+++ b/apps/web/src/_pages/mypage/ui/profile-section.tsx
@@ -2,15 +2,15 @@
 
 import { Pencil } from "@ui/icons";
 import { useState } from "react";
-import type { MypageProfile } from "../model/types";
-import ProfileAvatar from "./profile-avatar";
-import ProfileEditModal from "./profile-edit-modal";
+import type { MypageProfile } from "@/_pages/mypage/model/types";
+import { ProfileAvatar } from "@/_pages/mypage/ui/profile-avatar";
+import { ProfileEditModal } from "@/_pages/mypage/ui/profile-edit-modal";
 
 interface ProfileSectionProps {
   profile: MypageProfile;
 }
 
-export default function ProfileSection({ profile }: ProfileSectionProps) {
+export function ProfileSection({ profile }: ProfileSectionProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (

--- a/apps/web/src/app/(main)/mypage/page.tsx
+++ b/apps/web/src/app/(main)/mypage/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import MypagePage, { getMypagePageData, mypageTabs } from "@/_pages/mypage";
+import { getMypagePageData, MypageView, mypageTabs } from "@/_pages/mypage";
 import { getMyJoinedMeetings } from "@/_pages/mypage/queries/server";
 import { getApi, isAuth } from "@/shared/api/server";
 
@@ -28,7 +28,7 @@ export default async function Page() {
     });
 
     return (
-      <MypagePage
+      <MypageView
         initialFavoriteList={initialFavoriteList}
         profile={profile}
         tabs={mypageTabs}

--- a/apps/web/src/shared/ui/navigation-menu-client.tsx
+++ b/apps/web/src/shared/ui/navigation-menu-client.tsx
@@ -2,9 +2,9 @@
 
 import { Gnb, Sheet } from "@moum-zip/ui/components";
 import { Menu } from "@moum-zip/ui/icons";
+import Image from "next/image";
 import Link from "next/link";
 import { logoutAction } from "@/_pages/auth/actions";
-import { ProfileAvatar } from "@/_pages/mypage/ui/profile-avatar";
 import Logo from "@/shared/assets/moum-zip-logo.svg";
 import { NAVIGATION_ROUTES, ROUTES } from "@/shared/config/routes";
 
@@ -16,6 +16,39 @@ type NavigationMenuClientProps = {
     imageUrl?: string;
     name?: string;
   } | null;
+};
+
+interface NavigationProfileAvatarProps {
+  imageUrl?: string;
+  name?: string;
+}
+
+const NavigationProfileAvatar = ({ imageUrl, name }: NavigationProfileAvatarProps) => {
+  const initial = name?.trim().charAt(0) || "?";
+
+  if (imageUrl) {
+    return (
+      <div className="relative flex size-11 shrink-0 items-center justify-center rounded-full border border-border bg-card">
+        <Image
+          src={imageUrl}
+          alt={name ? `${name} 프로필 이미지` : "프로필 이미지"}
+          fill
+          className="rounded-full object-cover"
+          sizes="44px"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex size-11 shrink-0 items-center justify-center rounded-full border border-border bg-card font-semibold text-foreground text-sm"
+      role="img"
+      aria-label={name ? `${name} 프로필 이미지` : "프로필 이미지"}
+    >
+      {initial}
+    </div>
+  );
 };
 
 export const NavigationMenuClient = ({ loggedIn, user }: NavigationMenuClientProps) => {
@@ -53,11 +86,7 @@ export const NavigationMenuClient = ({ loggedIn, user }: NavigationMenuClientPro
                     aria-label="마이페이지로 이동"
                     className="inline-flex shrink-0 rounded-full transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-1"
                   >
-                    <ProfileAvatar
-                      className="size-11 border-border"
-                      src={user?.imageUrl}
-                      alt={user?.name ? `${user.name} 프로필 이미지` : "프로필 이미지"}
-                    />
+                    <NavigationProfileAvatar imageUrl={user?.imageUrl} name={user?.name} />
                   </Link>
                 </Gnb.Item>
               </>

--- a/apps/web/src/shared/ui/navigation-menu-client.tsx
+++ b/apps/web/src/shared/ui/navigation-menu-client.tsx
@@ -24,8 +24,6 @@ interface NavigationProfileAvatarProps {
 }
 
 const NavigationProfileAvatar = ({ imageUrl, name }: NavigationProfileAvatarProps) => {
-  const initial = name?.trim().charAt(0) || "?";
-
   if (imageUrl) {
     return (
       <div className="relative flex size-11 shrink-0 items-center justify-center rounded-full border border-border bg-card">
@@ -42,11 +40,19 @@ const NavigationProfileAvatar = ({ imageUrl, name }: NavigationProfileAvatarProp
 
   return (
     <div
-      className="flex size-11 shrink-0 items-center justify-center rounded-full border border-border bg-card font-semibold text-foreground text-sm"
+      className="flex size-11 shrink-0 items-center justify-center rounded-full border border-border bg-card"
       role="img"
       aria-label={name ? `${name} 프로필 이미지` : "프로필 이미지"}
     >
-      {initial}
+      <svg viewBox="0 0 24 24" className="size-6 text-muted-foreground" fill="none" aria-hidden="true">
+        <circle cx="12" cy="8" r="3.25" fill="currentColor" opacity="0.5" />
+        <path
+          d="M6.75 18.25C6.75 15.9028 9.09779 14 12 14C14.9022 14 17.25 15.9028 17.25 18.25"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+        />
+      </svg>
     </div>
   );
 };

--- a/apps/web/src/shared/ui/navigation-menu-client.tsx
+++ b/apps/web/src/shared/ui/navigation-menu-client.tsx
@@ -4,7 +4,7 @@ import { Gnb, Sheet } from "@moum-zip/ui/components";
 import { Menu } from "@moum-zip/ui/icons";
 import Link from "next/link";
 import { logoutAction } from "@/_pages/auth/actions";
-import ProfileAvatar from "@/_pages/mypage/ui/profile-avatar";
+import { ProfileAvatar } from "@/_pages/mypage/ui/profile-avatar";
 import Logo from "@/shared/assets/moum-zip-logo.svg";
 import { NAVIGATION_ROUTES, ROUTES } from "@/shared/config/routes";
 


### PR DESCRIPTION
## 📌 Summary

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- close #162 
- 마이페이지 관련 컴포넌트의 import/export 구조를 정리했습니다.
- default export로 작성되어 있던 마이페이지 UI 컴포넌트를 named export로 변경하고, 관련 import 구문을 함께 정리했습니다.

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- 마이페이지 UI 컴포넌트의 export 방식을 default export에서 named export로 정리했습니다.
- `index.ts`, `ui/index.ts`와 같이 export 진입점 역할을 하는 파일의 구조를 정리했습니다.
- 변경된 export 방식에 맞게 마이페이지 관련 import 구문을 함께 수정했습니다.
- 참조 경로 변경으로 인해 import/export 불일치가 없는지 함께 확인했습니다.

## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

- 이번 PR은 기능 변경 없이 import/export 구조 정리에 집중한 작업입니다.
- 마이페이지 관련 컴포넌트의 export 방식 변경이 적절한지 봐주시면 좋겠습니다.
- import 누락이나 잘못된 참조가 없는지 함께 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 모듈 import 경로를 상대 경로에서 절대 별칭으로 정리했습니다.
  * 여러 UI 컴포넌트의 기본(default) export를 명명(named) export로 통일해 import 방식 일관화 및 유지보수성 향상.
  * 사용자 동작/렌더링에는 영향이 없습니다.

* **New Features**
  * 내비게이션 아바타 렌더링 개선: 이미지가 있을 땐 최적화된 이미지로 표시하고, 없을 땐 이름 기반 대체 아바타(SVG)로 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->