### PR TITLE
[refactor] button, create-button shadcn 마이그레이션

### DIFF
--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -47,8 +47,14 @@ export function Button({
       className={cn(sizeClassMap[size], variantOverrideMap[variant], className)}
       {...props}
     >
-      {icon}
-      {children}
+      {asChild ? (
+        children
+      ) : (
+        <>
+          {icon}
+          {children}
+        </>
+      )}
     </ShadcnButton>
   );
 }

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -1,8 +1,7 @@
+import { Button as ShadcnButton } from "@ui/components/shadcn/button";
 import { cn } from "@ui/lib/utils";
-import { cva } from "class-variance-authority";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
-// types
 export type ButtonSize = "small" | "medium" | "large";
 export type ButtonVariant = "primary" | "secondary" | "tertiary";
 
@@ -10,37 +9,46 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size?: ButtonSize;
   variant?: ButtonVariant;
   icon?: ReactNode;
+  asChild?: boolean;
 }
 
-// variants
-const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-xl font-semibold transition-colors disabled:pointer-events-none",
-  {
-    variants: {
-      variant: {
-        primary: "bg-primary text-white hover:bg-green-600 disabled:bg-slate-100 disabled:text-slate-600",
-        secondary: "border border-primary bg-white text-green-600 hover:bg-primary/10", // text-primary -> text-green-600
-        tertiary: "bg-slate-200 text-slate-600 hover:bg-slate-300",
-      },
-      size: {
-        small: "h-10 min-w-[83px] whitespace-nowrap px-4 text-sm",
-        medium: "h-12 min-w-[311px] px-5 text-base",
-        large: "h-[60px] min-w-[474px] px-6 text-xl",
-      },
-    },
-    defaultVariants: {
-      variant: "primary",
-      size: "medium",
-    },
-  },
-);
+const variantMap: Record<ButtonVariant, "default" | "outline" | "secondary"> = {
+  primary: "default",
+  secondary: "outline",
+  tertiary: "secondary",
+};
 
-// component
-export function Button({ variant = "primary", size = "medium", className, icon, children, ...props }: ButtonProps) {
+const sizeClassMap: Record<ButtonSize, string> = {
+  small: "h-10 min-w-[83px] whitespace-nowrap px-4 text-sm",
+  medium: "h-12 min-w-[311px] px-5 text-base",
+  large: "h-[60px] min-w-[474px] px-6 text-xl",
+};
+
+const variantOverrideMap: Record<ButtonVariant, string> = {
+  primary:
+    "rounded-xl font-semibold bg-primary text-white hover:bg-green-600 disabled:bg-slate-100 disabled:text-slate-600",
+  secondary: "rounded-xl font-semibold border border-primary bg-white text-green-600 hover:bg-primary/10",
+  tertiary: "rounded-xl font-semibold bg-slate-200 text-slate-600 hover:bg-slate-300",
+};
+
+export function Button({
+  variant = "primary",
+  size = "medium",
+  className,
+  icon,
+  children,
+  asChild,
+  ...props
+}: ButtonProps) {
   return (
-    <button type="button" className={cn(buttonVariants({ variant, size }), className)} {...props}>
+    <ShadcnButton
+      variant={variantMap[variant]}
+      asChild={asChild}
+      className={cn(sizeClassMap[size], variantOverrideMap[variant], className)}
+      {...props}
+    >
       {icon}
       {children}
-    </button>
+    </ShadcnButton>
   );
 }

--- a/packages/ui/src/components/ui/create-button.tsx
+++ b/packages/ui/src/components/ui/create-button.tsx
@@ -25,11 +25,12 @@ interface CreateButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean;
 }
 
-export function CreateButton({ variant = "full", children, className, asChild, ...props }: CreateButtonProps) {
+export function CreateButton({ variant = "full", children, className, asChild, type, ...props }: CreateButtonProps) {
   return (
     <ShadcnButton
       variant="default"
       asChild={asChild}
+      type={asChild ? undefined : (type ?? "button")} // asChild가 아닐 때만 기본 type을 button으로 설정정
       className={cn(createButtonVariants({ variant }), className)}
       {...props}
     >

--- a/packages/ui/src/components/ui/create-button.tsx
+++ b/packages/ui/src/components/ui/create-button.tsx
@@ -30,8 +30,7 @@ export function CreateButton({ variant = "full", children, className, asChild, t
     <ShadcnButton
       variant="default"
       asChild={asChild}
-      type={asChild ? undefined : (type ?? "button")} // asChild가 아닐 때만 기본 type을 button으로 설정정
-      className={cn(createButtonVariants({ variant }), className)}
+      type={asChild ? undefined : (type ?? "button")} // asChild가 아닐 때만 기본 type을 button으로 설정
       {...props}
     >
       {asChild ? (

--- a/packages/ui/src/components/ui/create-button.tsx
+++ b/packages/ui/src/components/ui/create-button.tsx
@@ -29,13 +29,18 @@ export function CreateButton({ variant = "full", children, className, asChild, .
   return (
     <ShadcnButton
       variant="default"
-      size={null}
       asChild={asChild}
       className={cn(createButtonVariants({ variant }), className)}
       {...props}
     >
-      <Plus className="size-8" aria-hidden="true" />
-      {children}
+      {asChild ? (
+        children
+      ) : (
+        <>
+          <Plus className="size-8" aria-hidden="true" />
+          {children}
+        </>
+      )}
     </ShadcnButton>
   );
 }

--- a/packages/ui/src/components/ui/create-button.tsx
+++ b/packages/ui/src/components/ui/create-button.tsx
@@ -1,3 +1,4 @@
+import { Button as ShadcnButton } from "@ui/components/shadcn/button";
 import { cn } from "@ui/lib/utils";
 import { cva } from "class-variance-authority";
 import { Plus } from "lucide-react";
@@ -18,17 +19,23 @@ const createButtonVariants = cva(
   },
 );
 
-// ButtonHTMLAttributes 확장
-interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface CreateButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "full" | "icon";
   children?: ReactNode;
+  asChild?: boolean;
 }
 
-export function CreateButton({ variant = "full", children, className, ...props }: Props) {
+export function CreateButton({ variant = "full", children, className, asChild, ...props }: CreateButtonProps) {
   return (
-    <button type="button" className={cn(createButtonVariants({ variant }), className)} {...props}>
-      <Plus size={32} aria-hidden="true" />
+    <ShadcnButton
+      variant="default"
+      size={null}
+      asChild={asChild}
+      className={cn(createButtonVariants({ variant }), className)}
+      {...props}
+    >
+      <Plus className="size-8" aria-hidden="true" />
       {children}
-    </button>
+    </ShadcnButton>
   );
 }


### PR DESCRIPTION
## 📌 Summary

shadcn Button 기반으로 `button`, `create-button` 컴포넌트를 마이그레이션하여 `asChild` prop을 지원
기존 props 인터페이스(`ButtonProps`, `CreateButtonProps`) 및 variant/size API는 변경 없이 유지

- close #180

## 📄 Tasks

### button
- shadcn Button으로 교체
- 기존 variant(`primary`, `secondary`, `tertiary`) / size(`small`, `medium`, `large`) API 그대로 유지
- 내부에서 shadcn variant로 매핑 처리
- `asChild` prop 추가

### create-button
- shadcn Button으로 교체
- 기존 `full` / `icon` variant 유지
- cva 스타일 유지
- `asChild` prop 추가

### 제외 항목
| 컴포넌트 | 제외 사유 |
|---|---|
| `icon-button` | size 체계 및 variant 재설계 필요, 현재 asChild 필요 케이스 없음 → 필요 시 별도 이슈 대응 |
| `social-button` | Kakao / Google 고유 스타일로 인해 제외 |
| `utility-button` | gradient 로직 및 render props 패턴으로 인해 제외 |

## 👀 To Reviewer

기존 Button 사용처의 동작 변경은 없으며 `asChild`가 필요한 곳에서 아래와 같이 사용 가능합니다.

```tsx
<Button asChild>
  <Link href="...">버튼</Link>
</Button>
```

`CreateButton`에 `asChild` 사용 시 Radix Slot이 단일 element만 허용하므로 `Plus` 아이콘이 렌더링되지 않습니다. 아이콘이 필요하면 children 내부에 직접 포함해야 합니다!

```tsx
<CreateButton asChild>
  <Link href="...">
    <Plus className="size-8" />
    만들기
  </Link>
</CreateButton>
```

## 📸 Screenshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 버튼 컴포넌트와 생성 버튼에 asChild 옵션 추가로 렌더링을 더 유연하게 제어 가능

* **리팩토링**
  * 내부 버튼 구현을 공통 버튼 래퍼로 교체해 일관된 동작 제공
  * 스타일을 크기·변형별 맵과 오버라이드로 재정비하여 클래스 관리가 명확해짐
  * 생성 버튼의 아이콘 크기 및 버튼 타입 처리 방식(네이티브 타입 적용 조건)이 개선됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->