### PR TITLE
[style] 스페이스 찾기 페이지 UI 인터랙션 개선

### DIFF
--- a/apps/web/src/features/space-search/hooks/use-infinite-search-results.ts
+++ b/apps/web/src/features/space-search/hooks/use-infinite-search-results.ts
@@ -85,6 +85,7 @@ export const useInfiniteSearchResults = ({ isAuthenticated, queryState }: UseInf
   return {
     errorMessage,
     hasMore: Boolean(hasNextPage && !hasQueryError),
+    isFetchingNextPage,
     items,
     loadMoreRef,
   };

--- a/apps/web/src/features/space-search/ui/space-card-like-button.tsx
+++ b/apps/web/src/features/space-search/ui/space-card-like-button.tsx
@@ -175,7 +175,7 @@ export const SpaceCardLikeButton = ({ isAuthenticated, isLiked = false, meetingI
     <UtilityButton
       active={optimisticIsLiked}
       aria-label={optimisticIsLiked ? "좋아요 취소" : "좋아요 추가"}
-      className="shrink-0"
+      className="shrink-0 transition-transform duration-200 ease-out motion-reduce:transition-none lg:hover:scale-[1.03]"
       disabled={isPending}
       icon={optimisticIsLiked ? ActiveHeartIcon : DefaultHeartIcon}
       onClick={handleClick}

--- a/apps/web/src/features/space-search/ui/space-card-skeleton.tsx
+++ b/apps/web/src/features/space-search/ui/space-card-skeleton.tsx
@@ -7,7 +7,7 @@ const skeletonBlockClassName = "rounded-full bg-muted";
 export const SpaceCardSkeleton = () => {
   return (
     <div className="rounded-[2.25rem]">
-      <article aria-hidden="true" className={`${skeletonCardClassName} animate-pulse`}>
+      <article aria-hidden="true" className={`${skeletonCardClassName} animate-pulse motion-reduce:animate-none`}>
         <div className="relative w-full shrink-0 sm:w-full md:w-auto">
           <div className={skeletonImageClassName} />
           <div className="absolute top-4 right-4 size-10 rounded-full bg-muted sm:hidden" />

--- a/apps/web/src/features/space-search/ui/space-card-skeleton.tsx
+++ b/apps/web/src/features/space-search/ui/space-card-skeleton.tsx
@@ -1,0 +1,42 @@
+const skeletonCardClassName =
+  "relative flex w-full min-w-0 flex-col gap-0 overflow-hidden rounded-[2rem] bg-card shadow-[0_10px_24px_rgba(17,17,17,0.09)] sm:gap-6 sm:overflow-visible sm:p-6 md:flex-row md:items-center lg:gap-5 lg:p-5 2xl:gap-6 2xl:p-6";
+const skeletonImageClassName =
+  "h-39 w-full rounded-none bg-muted sm:h-50 sm:rounded-3xl md:size-42.5 lg:size-40 2xl:size-42.5";
+const skeletonBlockClassName = "rounded-full bg-muted";
+
+export const SpaceCardSkeleton = () => {
+  return (
+    <div className="rounded-[2.25rem]">
+      <article aria-hidden="true" className={`${skeletonCardClassName} animate-pulse`}>
+        <div className="relative w-full shrink-0 sm:w-full md:w-auto">
+          <div className={skeletonImageClassName} />
+          <div className="absolute top-4 right-4 size-10 rounded-full bg-muted sm:hidden" />
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-5 p-4 sm:p-0">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-2">
+                <div className="h-7 w-3/5 max-w-52 rounded-full bg-muted" />
+              </div>
+              <div className="mt-3 flex items-center gap-2">
+                <div className={`h-4 w-24 ${skeletonBlockClassName}`} />
+                <div className={`h-4 w-14 ${skeletonBlockClassName}`} />
+              </div>
+            </div>
+
+            <div className="hidden size-10 rounded-full bg-muted sm:block" />
+          </div>
+
+          <div className="mt-auto flex items-end justify-between gap-3 lg:gap-2.5 2xl:gap-3">
+            <div className="flex min-w-0 flex-1 flex-col gap-3">
+              <div className={`h-5 w-32 ${skeletonBlockClassName}`} />
+              <div className={`h-3.5 w-full max-w-64.5 ${skeletonBlockClassName} lg:max-w-60 2xl:max-w-64.5`} />
+            </div>
+            <div className="h-12 min-w-26 shrink-0 rounded-xl bg-muted lg:h-11 lg:min-w-24 2xl:h-12 2xl:min-w-26" />
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+};

--- a/apps/web/src/features/space-search/ui/space-card.tsx
+++ b/apps/web/src/features/space-search/ui/space-card.tsx
@@ -81,82 +81,84 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
   );
 
   return (
-    <article className="relative flex w-full min-w-0 flex-col gap-0 overflow-hidden rounded-[2rem] bg-card shadow-[0_20px_50px_rgba(17,17,17,0.04)] sm:gap-6 sm:overflow-visible sm:p-6 md:flex-row md:items-center lg:gap-5 lg:p-5 2xl:gap-6 2xl:p-6">
-      <Link
-        aria-label={`${title} 상세 페이지 보기`}
-        className="absolute inset-0 z-10 rounded-[2rem] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-        href={detailHref}
-        prefetch={false}
-      />
-      <div className="relative w-full shrink-0 sm:w-full md:w-auto">
-        <Image
-          alt={imageAlt}
-          className="h-39 w-full object-cover sm:h-50 sm:rounded-3xl md:size-42.5 lg:size-40 2xl:size-42.5"
-          height={340}
-          src={imageSrc}
-          unoptimized
-          width={340}
+    <div className="group/card -m-1 rounded-[2.25rem] p-1">
+      <article className="relative flex w-full min-w-0 flex-col gap-0 overflow-hidden rounded-[2rem] bg-card shadow-[0_10px_24px_rgba(17,17,17,0.09)] transition-[transform,box-shadow] duration-300 ease-out motion-reduce:transition-none sm:gap-6 sm:overflow-visible sm:p-6 md:flex-row md:items-center lg:gap-5 lg:p-5 lg:group-hover/card:-translate-y-0.5 lg:group-hover/card:shadow-[0_16px_32px_rgba(17,17,17,0.14)] motion-reduce:lg:group-hover/card:translate-y-0 2xl:gap-6 2xl:p-6">
+        <Link
+          aria-label={`${title} 상세 페이지 보기`}
+          className="absolute inset-0 z-10 rounded-[2rem] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          href={detailHref}
+          prefetch={false}
         />
-        <div className="absolute top-4 right-4 z-20 sm:hidden">
-          <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={meetingId} />
-        </div>
-      </div>
-
-      <div className="flex min-w-0 flex-1 flex-col gap-5 p-4 sm:p-0">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 items-center gap-2">
-              <h2
-                className="min-w-0 flex-1 truncate font-semibold text-foreground text-xl leading-normal tracking-[-0.04em]"
-                title={title}
-              >
-                {displayTitle}
-              </h2>
-              {status ? <SpaceCardStatus className="shrink-0" label={status.label} /> : null}
-            </div>
-            <p className="mt-1.5 inline-flex items-center gap-1 font-medium text-muted-foreground text-sm leading-5 tracking-[-0.02em]">
-              <LocationPinIcon aria-hidden="true" className="size-4 shrink-0" />
-              <span>{district}</span>
-              <span aria-hidden="true">|</span>
-              <span>{category}</span>
-            </p>
-          </div>
-
-          <div className="relative z-20 hidden sm:block">
+        <div className="relative w-full shrink-0 sm:w-full md:w-auto">
+          <Image
+            alt={imageAlt}
+            className="h-39 w-full object-cover transition-transform duration-300 ease-out motion-reduce:transition-none sm:h-50 sm:rounded-3xl md:size-42.5 lg:size-40 lg:group-hover/card:scale-[1.015] motion-reduce:lg:group-hover/card:scale-100 2xl:size-42.5"
+            height={340}
+            src={imageSrc}
+            unoptimized
+            width={340}
+          />
+          <div className="absolute top-4 right-4 z-20 sm:hidden">
             <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={meetingId} />
           </div>
         </div>
 
-        <div className="flex items-end justify-between gap-3 lg:gap-2.5 2xl:gap-3">
-          <div className="flex min-w-0 flex-1 flex-col gap-6 sm:gap-4 lg:gap-3.5 2xl:gap-4">
-            <div className="flex items-center gap-1.5 whitespace-nowrap">
-              <div className="flex items-center gap-2">
-                {metaChips.map((chip) => (
-                  <MetaChip chip={chip} key={chip.id} />
-                ))}
+        <div className="flex min-w-0 flex-1 flex-col gap-5 p-4 sm:p-0">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-2">
+                <h2
+                  className="min-w-0 flex-1 truncate font-semibold text-foreground text-xl leading-normal tracking-[-0.04em] transition-colors duration-300 motion-reduce:transition-none lg:group-hover/card:text-primary"
+                  title={title}
+                >
+                  {displayTitle}
+                </h2>
+                {status ? <SpaceCardStatus className="shrink-0" label={status.label} /> : null}
               </div>
-              <Tag size="small" className={deadlineTagClassName} icon>
-                {deadlineLabel}
-              </Tag>
+              <p className="mt-1.5 inline-flex items-center gap-1 font-medium text-muted-foreground text-sm leading-5 tracking-[-0.02em]">
+                <LocationPinIcon aria-hidden="true" className="size-4 shrink-0" />
+                <span>{district}</span>
+                <span aria-hidden="true">|</span>
+                <span>{category}</span>
+              </p>
             </div>
-            <LabeledProgressBar
-              aria-label={`${title} 참여 현황`}
-              className="mb-3.5 w-full max-w-64.5 sm:mb-0 lg:max-w-60 2xl:max-w-64.5"
-              maxValue={maxParticipants}
-              value={currentParticipants}
-            />
+
+            <div className="relative z-20 hidden sm:block">
+              <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={meetingId} />
+            </div>
           </div>
 
-          <SpaceCardJoinButton
-            className={joinButtonClassName}
-            disabled={isRegistClosed}
-            size="small"
-            variant={isRegistClosed ? "primary" : "secondary"}
-          >
-            {isRegistClosed ? "모집 마감" : "참여하기"}
-          </SpaceCardJoinButton>
+          <div className="flex items-end justify-between gap-3 lg:gap-2.5 2xl:gap-3">
+            <div className="flex min-w-0 flex-1 flex-col gap-6 sm:gap-4 lg:gap-3.5 2xl:gap-4">
+              <div className="flex items-center gap-1.5 whitespace-nowrap">
+                <div className="flex items-center gap-2">
+                  {metaChips.map((chip) => (
+                    <MetaChip chip={chip} key={chip.id} />
+                  ))}
+                </div>
+                <Tag size="small" className={deadlineTagClassName} icon>
+                  {deadlineLabel}
+                </Tag>
+              </div>
+              <LabeledProgressBar
+                aria-label={`${title} 참여 현황`}
+                className="mb-3.5 w-full max-w-64.5 sm:mb-0 lg:max-w-60 2xl:max-w-64.5"
+                maxValue={maxParticipants}
+                value={currentParticipants}
+              />
+            </div>
+
+            <SpaceCardJoinButton
+              className={joinButtonClassName}
+              disabled={isRegistClosed}
+              size="small"
+              variant={isRegistClosed ? "primary" : "secondary"}
+            >
+              {isRegistClosed ? "모집 마감" : "참여하기"}
+            </SpaceCardJoinButton>
+          </div>
         </div>
-      </div>
-    </article>
+      </article>
+    </div>
   );
 };

--- a/apps/web/src/features/space-search/ui/space-card.tsx
+++ b/apps/web/src/features/space-search/ui/space-card.tsx
@@ -35,6 +35,13 @@ const deadlineTagClassName = cn(
   "2xl:[&>span:last-child]:max-w-none 2xl:[&>span:last-child]:overflow-visible 2xl:[&>span:last-child]:text-clip 2xl:[&>span:last-child]:text-xs 2xl:[&>span:last-child]:leading-4",
   "lg:[&>svg]:size-[1.125rem] 2xl:[&>svg]:size-5",
 );
+const cardWrapperClassName = "group/card -m-1 rounded-[2.25rem] p-1";
+const cardClassName =
+  "relative flex w-full min-w-0 flex-col gap-0 overflow-hidden rounded-[2rem] bg-card shadow-[0_10px_24px_rgba(17,17,17,0.09)] transition-[transform,box-shadow] duration-300 ease-out motion-reduce:transition-none sm:gap-6 sm:overflow-visible sm:p-6 md:flex-row md:items-center lg:gap-5 lg:p-5 lg:group-hover/card:-translate-y-0.5 lg:group-hover/card:shadow-[0_16px_32px_rgba(17,17,17,0.14)] motion-reduce:lg:group-hover/card:translate-y-0 2xl:gap-6 2xl:p-6";
+const cardImageClassName =
+  "h-39 w-full object-cover transition-transform duration-300 ease-out motion-reduce:transition-none sm:h-50 sm:rounded-3xl md:size-42.5 lg:size-40 lg:group-hover/card:scale-[1.015] motion-reduce:lg:group-hover/card:scale-100 2xl:size-42.5";
+const cardTitleClassName =
+  "min-w-0 flex-1 truncate font-semibold text-foreground text-xl leading-normal tracking-[-0.04em] transition-colors duration-300 motion-reduce:transition-none lg:group-hover/card:text-primary";
 
 const MetaChip = ({ chip }: MetaChipProps) => {
   return (
@@ -79,10 +86,11 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
       "cursor-not-allowed opacity-60 active:scale-100": isRegistClosed,
     },
   );
+  const likeButtonProps = { isAuthenticated, isLiked, meetingId };
 
   return (
-    <div className="group/card -m-1 rounded-[2.25rem] p-1">
-      <article className="relative flex w-full min-w-0 flex-col gap-0 overflow-hidden rounded-[2rem] bg-card shadow-[0_10px_24px_rgba(17,17,17,0.09)] transition-[transform,box-shadow] duration-300 ease-out motion-reduce:transition-none sm:gap-6 sm:overflow-visible sm:p-6 md:flex-row md:items-center lg:gap-5 lg:p-5 lg:group-hover/card:-translate-y-0.5 lg:group-hover/card:shadow-[0_16px_32px_rgba(17,17,17,0.14)] motion-reduce:lg:group-hover/card:translate-y-0 2xl:gap-6 2xl:p-6">
+    <div className={cardWrapperClassName}>
+      <article className={cardClassName}>
         <Link
           aria-label={`${title} 상세 페이지 보기`}
           className="absolute inset-0 z-10 rounded-[2rem] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
@@ -90,16 +98,9 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
           prefetch={false}
         />
         <div className="relative w-full shrink-0 sm:w-full md:w-auto">
-          <Image
-            alt={imageAlt}
-            className="h-39 w-full object-cover transition-transform duration-300 ease-out motion-reduce:transition-none sm:h-50 sm:rounded-3xl md:size-42.5 lg:size-40 lg:group-hover/card:scale-[1.015] motion-reduce:lg:group-hover/card:scale-100 2xl:size-42.5"
-            height={340}
-            src={imageSrc}
-            unoptimized
-            width={340}
-          />
+          <Image alt={imageAlt} className={cardImageClassName} height={340} src={imageSrc} unoptimized width={340} />
           <div className="absolute top-4 right-4 z-20 sm:hidden">
-            <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={meetingId} />
+            <SpaceCardLikeButton {...likeButtonProps} />
           </div>
         </div>
 
@@ -107,10 +108,7 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0 flex-1">
               <div className="flex min-w-0 items-center gap-2">
-                <h2
-                  className="min-w-0 flex-1 truncate font-semibold text-foreground text-xl leading-normal tracking-[-0.04em] transition-colors duration-300 motion-reduce:transition-none lg:group-hover/card:text-primary"
-                  title={title}
-                >
+                <h2 className={cardTitleClassName} title={title}>
                   {displayTitle}
                 </h2>
                 {status ? <SpaceCardStatus className="shrink-0" label={status.label} /> : null}
@@ -124,7 +122,7 @@ export const SpaceCard = ({ isAuthenticated, item }: SpaceCardProps) => {
             </div>
 
             <div className="relative z-20 hidden sm:block">
-              <SpaceCardLikeButton isAuthenticated={isAuthenticated} isLiked={isLiked} meetingId={meetingId} />
+              <SpaceCardLikeButton {...likeButtonProps} />
             </div>
           </div>
 

--- a/apps/web/src/features/space-search/ui/space-search-create-button.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-create-button.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import type { MouseEventHandler, ReactNode } from "react";
 
 import { ROUTES } from "@/shared/config/routes";
+import { cn } from "@/shared/lib/cn";
 import { showRequiredToast } from "@/shared/lib/toast-utils";
 
 interface SearchCreateButtonProps {
@@ -36,6 +37,17 @@ export const SearchCreateButton = ({
   onClick,
   variant = "full",
 }: SearchCreateButtonProps) => {
+  const createButtonClassName = cn(
+    "border-0 shadow-[0_8px_18px_rgba(31,95,76,0.28)] transition-[transform,box-shadow,background-color] duration-300 ease-out active:translate-y-0 motion-reduce:transition-none lg:group-hover/create:-translate-y-0.5 lg:group-hover/create:shadow-[0_12px_22px_rgba(31,95,76,0.34)] motion-reduce:lg:group-hover/create:translate-y-0",
+    variant === "icon" &&
+      "shadow-[0_8px_16px_rgba(31,95,76,0.26)] lg:group-hover/create:shadow-[0_10px_20px_rgba(31,95,76,0.32)]",
+    className,
+  );
+  const createButtonWrapperClassName = cn(
+    "group/create pointer-events-auto -m-1 inline-flex",
+    variant === "icon" ? "rounded-full" : "rounded-[1.75rem]",
+  );
+
   const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
     onClick?.(event);
 
@@ -48,15 +60,17 @@ export const SearchCreateButton = ({
 
   if (!isAuthenticated || disabled) {
     return (
-      <CreateButton
-        aria-label={ariaLabel}
-        className={className}
-        disabled={disabled}
-        onClick={handleClick}
-        variant={variant}
-      >
-        {children}
-      </CreateButton>
+      <span className={createButtonWrapperClassName}>
+        <CreateButton
+          aria-label={ariaLabel}
+          className={createButtonClassName}
+          disabled={disabled}
+          onClick={handleClick}
+          variant={variant}
+        >
+          {children}
+        </CreateButton>
+      </span>
     );
   }
 
@@ -65,10 +79,12 @@ export const SearchCreateButton = ({
   };
 
   return (
-    <CreateButton aria-label={ariaLabel} asChild className={className} variant={variant}>
-      <Link href={ROUTES.moimCreate} onClick={handleLinkClick}>
-        {renderCreateButtonContent(children)}
-      </Link>
-    </CreateButton>
+    <span className={createButtonWrapperClassName}>
+      <CreateButton aria-label={ariaLabel} asChild className={createButtonClassName} variant={variant}>
+        <Link href={ROUTES.moimCreate} onClick={handleLinkClick}>
+          {renderCreateButtonContent(children)}
+        </Link>
+      </CreateButton>
+    </span>
   );
 };

--- a/apps/web/src/features/space-search/ui/space-search-create-button.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-create-button.tsx
@@ -47,6 +47,12 @@ export const SearchCreateButton = ({
     "group/create pointer-events-auto -m-1 inline-flex",
     variant === "icon" ? "rounded-full" : "rounded-[1.75rem]",
   );
+  const isLinkButton = isAuthenticated && !disabled;
+  const createButtonProps = {
+    "aria-label": ariaLabel,
+    className: createButtonClassName,
+    variant,
+  } as const;
 
   const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
     onClick?.(event);
@@ -58,33 +64,21 @@ export const SearchCreateButton = ({
     showRequiredToast("로그인 후 이용할 수 있어요.");
   };
 
-  if (!isAuthenticated || disabled) {
-    return (
-      <span className={createButtonWrapperClassName}>
-        <CreateButton
-          aria-label={ariaLabel}
-          className={createButtonClassName}
-          disabled={disabled}
-          onClick={handleClick}
-          variant={variant}
-        >
-          {children}
-        </CreateButton>
-      </span>
-    );
-  }
-
   const handleLinkClick: MouseEventHandler<HTMLAnchorElement> = (event) => {
     onClick?.(event);
   };
 
-  return (
-    <span className={createButtonWrapperClassName}>
-      <CreateButton aria-label={ariaLabel} asChild className={createButtonClassName} variant={variant}>
-        <Link href={ROUTES.moimCreate} onClick={handleLinkClick}>
-          {renderCreateButtonContent(children)}
-        </Link>
-      </CreateButton>
-    </span>
+  const createButtonElement = isLinkButton ? (
+    <CreateButton {...createButtonProps} asChild>
+      <Link href={ROUTES.moimCreate} onClick={handleLinkClick}>
+        {renderCreateButtonContent(children)}
+      </Link>
+    </CreateButton>
+  ) : (
+    <CreateButton {...createButtonProps} disabled={disabled} onClick={handleClick}>
+      {children}
+    </CreateButton>
   );
+
+  return <span className={createButtonWrapperClassName}>{createButtonElement}</span>;
 };

--- a/apps/web/src/features/space-search/ui/space-search-results.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-results.tsx
@@ -3,16 +3,25 @@ import type { RefObject } from "react";
 
 import type { SpaceCardItem } from "../model/types";
 import { SpaceCard } from "./space-card";
+import { SpaceCardSkeleton } from "./space-card-skeleton";
 
 interface SearchResultsProps {
   errorMessage?: string;
   hasMore: boolean;
+  isFetchingNextPage: boolean;
   isAuthenticated: boolean;
   items: SpaceCardItem[];
   loadMoreRef: RefObject<HTMLDivElement | null>;
 }
 
-export const SearchResults = ({ errorMessage, hasMore, isAuthenticated, items, loadMoreRef }: SearchResultsProps) => {
+export const SearchResults = ({
+  errorMessage,
+  hasMore,
+  isFetchingNextPage,
+  isAuthenticated,
+  items,
+  loadMoreRef,
+}: SearchResultsProps) => {
   if (items.length === 0) {
     return (
       <section className="rounded-[2rem] px-6 py-16">
@@ -33,7 +42,16 @@ export const SearchResults = ({ errorMessage, hasMore, isAuthenticated, items, l
       {errorMessage ? (
         <p className="text-center font-medium text-destructive text-sm leading-5">{errorMessage}</p>
       ) : null}
-      {hasMore ? <div aria-hidden="true" className="h-4 w-full" ref={loadMoreRef} /> : null}
+      {hasMore && !isFetchingNextPage ? <div aria-hidden="true" className="h-4 w-full" ref={loadMoreRef} /> : null}
+      {isFetchingNextPage ? (
+        <div className="grid gap-6 lg:grid-cols-2">
+          <SpaceCardSkeleton />
+          <SpaceCardSkeleton />
+        </div>
+      ) : null}
+      {!hasMore && !errorMessage && !isFetchingNextPage ? (
+        <p className="text-center font-medium text-muted-foreground text-sm leading-5">더 이상 스페이스가 없어요.</p>
+      ) : null}
     </section>
   );
 };

--- a/apps/web/src/features/space-search/ui/space-search-results.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-results.tsx
@@ -44,10 +44,15 @@ export const SearchResults = ({
       ) : null}
       {hasMore && !isFetchingNextPage ? <div aria-hidden="true" className="h-4 w-full" ref={loadMoreRef} /> : null}
       {isFetchingNextPage ? (
-        <div className="grid gap-6 lg:grid-cols-2">
-          <SpaceCardSkeleton />
-          <SpaceCardSkeleton />
-        </div>
+        <>
+          <p aria-live="polite" className="sr-only">
+            검색 결과를 더 불러오는 중이에요.
+          </p>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <SpaceCardSkeleton />
+            <SpaceCardSkeleton />
+          </div>
+        </>
       ) : null}
       {!hasMore && !errorMessage && !isFetchingNextPage ? (
         <p className="text-center font-medium text-muted-foreground text-sm leading-5">더 이상 스페이스가 없어요.</p>

--- a/apps/web/src/features/space-search/ui/space-search-sections.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-sections.tsx
@@ -28,6 +28,15 @@ export const SearchContentSection = ({ categories, isAuthenticated, queryState }
     isAuthenticated,
     queryState: activeQueryState,
   });
+  const handleFilterOpenChange = (filterId: SearchFilter["id"], nextIsOpen: boolean) => {
+    setOpenedFilterId((prevOpenedFilterId) => {
+      if (nextIsOpen) {
+        return filterId;
+      }
+
+      return prevOpenedFilterId === filterId ? null : prevOpenedFilterId;
+    });
+  };
 
   return (
     <>
@@ -35,7 +44,7 @@ export const SearchContentSection = ({ categories, isAuthenticated, queryState }
         <SearchToolbar
           categories={categories}
           filters={SEARCH_FILTERS}
-          onFilterOpenChange={setOpenedFilterId}
+          onFilterOpenChange={handleFilterOpenChange}
           onCategoryChange={handleCategoryChange}
           onDateSortChange={handleDateSortChange}
           onDeadlineSortChange={handleDeadlineSortChange}

--- a/apps/web/src/features/space-search/ui/space-search-sections.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-sections.tsx
@@ -24,7 +24,7 @@ export const SearchContentSection = ({ categories, isAuthenticated, queryState }
     handleDeadlineSortChange,
     handleLocationChange,
   } = useSearchQueryState({ queryState });
-  const { errorMessage, hasMore, items, loadMoreRef } = useInfiniteSearchResults({
+  const { errorMessage, hasMore, isFetchingNextPage, items, loadMoreRef } = useInfiniteSearchResults({
     isAuthenticated,
     queryState: activeQueryState,
   });
@@ -60,6 +60,7 @@ export const SearchContentSection = ({ categories, isAuthenticated, queryState }
         <SearchResults
           errorMessage={errorMessage}
           hasMore={hasMore}
+          isFetchingNextPage={isFetchingNextPage}
           isAuthenticated={isAuthenticated}
           items={items}
           loadMoreRef={loadMoreRef}

--- a/apps/web/src/features/space-search/ui/space-search-sections.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-sections.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useState } from "react";
+
 import { useInfiniteSearchResults } from "../hooks/use-infinite-search-results";
 import { useSearchQueryState } from "../hooks/use-search-query-state";
 import { SEARCH_FILTERS } from "../model/constants";
-import type { SearchCategory, SearchQueryState } from "../model/types";
+import type { SearchCategory, SearchFilter, SearchQueryState } from "../model/types";
 import { SearchResults } from "./space-search-results";
 import { SearchToolbar } from "./space-search-toolbar";
 
@@ -14,6 +16,7 @@ interface SearchContentSectionProps {
 }
 
 export const SearchContentSection = ({ categories, isAuthenticated, queryState }: SearchContentSectionProps) => {
+  const [openedFilterId, setOpenedFilterId] = useState<SearchFilter["id"] | null>(null);
   const {
     activeQueryState,
     handleCategoryChange,
@@ -32,10 +35,12 @@ export const SearchContentSection = ({ categories, isAuthenticated, queryState }
         <SearchToolbar
           categories={categories}
           filters={SEARCH_FILTERS}
+          onFilterOpenChange={setOpenedFilterId}
           onCategoryChange={handleCategoryChange}
           onDateSortChange={handleDateSortChange}
           onDeadlineSortChange={handleDeadlineSortChange}
           onLocationChange={handleLocationChange}
+          openedFilterId={openedFilterId}
           selectedCategoryId={activeQueryState.categoryId}
           selectedDateSortId={activeQueryState.dateSortId}
           selectedDeadlineSortId={activeQueryState.deadlineSortId}

--- a/apps/web/src/features/space-search/ui/space-search-toolbar.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-toolbar.tsx
@@ -1,6 +1,5 @@
 import { Dropdown, Filter, TabButton } from "@ui/components";
 import { ChevronDown } from "@ui/icons";
-import type { Dispatch, SetStateAction } from "react";
 
 import { cn } from "@/shared/lib/cn";
 
@@ -16,7 +15,7 @@ import type {
 interface SearchToolbarProps {
   categories: SearchCategory[];
   filters: SearchFilter[];
-  onFilterOpenChange: Dispatch<SetStateAction<SearchFilter["id"] | null>>;
+  onFilterOpenChange: (filterId: SearchFilter["id"], nextIsOpen: boolean) => void;
   onCategoryChange: (categoryId: SearchCategory["id"]) => void;
   onDateSortChange: (dateSortId: SearchDateSortId) => void;
   onDeadlineSortChange: (deadlineSortId: SearchDeadlineSortId) => void;
@@ -28,23 +27,22 @@ interface SearchToolbarProps {
   selectedLocationId: SearchQueryState["locationId"];
 }
 
-const getSelectedFilterOptionId = (
-  filterId: SearchFilter["id"],
-  {
-    selectedDateSortId,
-    selectedDeadlineSortId,
-    selectedLocationId,
-  }: Pick<SearchToolbarProps, "selectedDateSortId" | "selectedDeadlineSortId" | "selectedLocationId">,
-) => {
-  if (filterId === "date") {
-    return selectedDateSortId;
-  }
+const CATEGORY_TAB_CLASS_NAME =
+  "transition-[transform,background-color] duration-200 ease-out motion-reduce:transition-none lg:group-hover/tab:-translate-y-0.5 motion-reduce:lg:group-hover/tab:translate-y-0";
+const FILTER_TRIGGER_CLASS_NAME =
+  "cursor-pointer rounded-full text-sm transition-[background-color,border-color,color,box-shadow]";
+const FILTER_CHEVRON_CLASS_NAME = "transition-transform duration-200 ease-out motion-reduce:transition-none";
 
-  if (filterId === "location") {
-    return selectedLocationId;
-  }
+const getFilterTriggerClassName = (isOpen: boolean, isSelected: boolean) => {
+  return cn(
+    FILTER_TRIGGER_CLASS_NAME,
+    isOpen && !isSelected && "text-foreground/70",
+    isSelected && "border border-primary/35 bg-primary/10 shadow-[inset_0_0_0_1px_rgba(31,95,76,0.02)]",
+  );
+};
 
-  return selectedDeadlineSortId;
+const getFilterChevronClassName = (isOpen: boolean, isSelected: boolean) => {
+  return cn(FILTER_CHEVRON_CLASS_NAME, isSelected && "text-primary", isOpen && "rotate-180");
 };
 
 export const SearchToolbar = ({
@@ -61,6 +59,12 @@ export const SearchToolbar = ({
   selectedDeadlineSortId,
   selectedLocationId,
 }: SearchToolbarProps) => {
+  const selectedFilterOptionIdById: Record<SearchFilter["id"], string> = {
+    date: selectedDateSortId,
+    deadline: selectedDeadlineSortId,
+    location: selectedLocationId,
+  };
+
   const handleFilterChange = (filterId: SearchFilter["id"], optionId: string) => {
     if (filterId === "date") {
       onDateSortChange(optionId as SearchDateSortId);
@@ -83,7 +87,7 @@ export const SearchToolbar = ({
             <TabButton
               aria-pressed={selectedCategoryId === id}
               className={cn(
-                "transition-[transform,background-color] duration-200 ease-out motion-reduce:transition-none lg:group-hover/tab:-translate-y-0.5 motion-reduce:lg:group-hover/tab:translate-y-0",
+                CATEGORY_TAB_CLASS_NAME,
                 selectedCategoryId !== id && "bg-muted hover:bg-border-subtle",
                 selectedCategoryId === id && "lg:-translate-y-0.5",
               )}
@@ -100,11 +104,7 @@ export const SearchToolbar = ({
       <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 lg:justify-end">
         {filters.map((filter) => {
           const defaultOption = filter.options[0];
-          const selectedOptionId = getSelectedFilterOptionId(filter.id, {
-            selectedDateSortId,
-            selectedDeadlineSortId,
-            selectedLocationId,
-          });
+          const selectedOptionId = selectedFilterOptionIdById[filter.id];
           const selectedOption = filter.options.find(({ id }) => id === selectedOptionId) ?? defaultOption;
           const isOpen = openedFilterId === filter.id;
           const isSelected = selectedOption.id !== defaultOption?.id;
@@ -112,35 +112,16 @@ export const SearchToolbar = ({
           return (
             <Dropdown
               key={filter.id}
-              onOpenChange={(nextIsOpen) => {
-                onFilterOpenChange((prevOpenedFilterId) => {
-                  if (nextIsOpen) {
-                    return filter.id;
-                  }
-
-                  return prevOpenedFilterId === filter.id ? null : prevOpenedFilterId;
-                });
-              }}
+              onOpenChange={(nextIsOpen) => onFilterOpenChange(filter.id, nextIsOpen)}
               open={isOpen}
             >
               <Dropdown.Trigger>
                 <Filter
-                  className={cn(
-                    "cursor-pointer rounded-full text-sm transition-[background-color,border-color,color,box-shadow]",
-                    isOpen && !isSelected && "cursor-pointer text-foreground/70",
-                    isSelected && "border border-primary/35 bg-primary/10 shadow-[inset_0_0_0_1px_rgba(31,95,76,0.02)]",
-                  )}
+                  className={getFilterTriggerClassName(isOpen, isSelected)}
                   label={selectedOption.label}
                   leftIcon={null}
                   rightIcon={
-                    <ChevronDown
-                      className={cn(
-                        "transition-transform duration-200 ease-out motion-reduce:transition-none",
-                        isSelected && "text-primary",
-                        isOpen && "rotate-180",
-                      )}
-                      strokeWidth={1.8}
-                    />
+                    <ChevronDown className={getFilterChevronClassName(isOpen, isSelected)} strokeWidth={1.8} />
                   }
                   selected={isSelected}
                   size="small"

--- a/apps/web/src/features/space-search/ui/space-search-toolbar.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-toolbar.tsx
@@ -1,4 +1,7 @@
 import { Dropdown, Filter, TabButton } from "@ui/components";
+import { ChevronDown } from "@ui/icons";
+
+import { cn } from "@/shared/lib/cn";
 
 import type {
   SearchCategory,
@@ -12,10 +15,12 @@ import type {
 interface SearchToolbarProps {
   categories: SearchCategory[];
   filters: SearchFilter[];
+  onFilterOpenChange: (filterId: SearchFilter["id"] | null) => void;
   onCategoryChange: (categoryId: SearchCategory["id"]) => void;
   onDateSortChange: (dateSortId: SearchDateSortId) => void;
   onDeadlineSortChange: (deadlineSortId: SearchDeadlineSortId) => void;
   onLocationChange: (locationId: SearchLocationId) => void;
+  openedFilterId: SearchFilter["id"] | null;
   selectedCategoryId: SearchQueryState["categoryId"];
   selectedDateSortId: SearchQueryState["dateSortId"];
   selectedDeadlineSortId: SearchQueryState["deadlineSortId"];
@@ -44,10 +49,12 @@ const getSelectedFilterOptionId = (
 export const SearchToolbar = ({
   categories,
   filters,
+  onFilterOpenChange,
   onCategoryChange,
   onDateSortChange,
   onDeadlineSortChange,
   onLocationChange,
+  openedFilterId,
   selectedCategoryId,
   selectedDateSortId,
   selectedDeadlineSortId,
@@ -71,19 +78,25 @@ export const SearchToolbar = ({
     <section className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
       <div className="no-scrollbar flex flex-wrap items-center gap-2 overflow-x-hidden pb-1">
         {categories.map(({ id, label }) => (
-          <TabButton
-            aria-pressed={selectedCategoryId === id}
-            key={id}
-            onClick={() => onCategoryChange(id)}
-            size="small"
-            variant={selectedCategoryId === id ? "active" : "default"}
-          >
-            {label}
-          </TabButton>
+          <div className="group/tab rounded-[1rem] p-0.5" key={id}>
+            <TabButton
+              aria-pressed={selectedCategoryId === id}
+              className={cn(
+                "transition-[transform,background-color] duration-200 ease-out motion-reduce:transition-none lg:group-hover/tab:-translate-y-0.5 motion-reduce:lg:group-hover/tab:translate-y-0",
+                selectedCategoryId !== id && "bg-muted hover:bg-border-subtle",
+                selectedCategoryId === id && "lg:-translate-y-0.5",
+              )}
+              onClick={() => onCategoryChange(id)}
+              size="small"
+              variant={selectedCategoryId === id ? "active" : "default"}
+            >
+              {label}
+            </TabButton>
+          </div>
         ))}
       </div>
 
-      <div className="flex flex-wrap items-center gap-x-0.5 gap-y-1 lg:justify-end">
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 lg:justify-end">
         {filters.map((filter) => {
           const defaultOption = filter.options[0];
           const selectedOptionId = getSelectedFilterOptionId(filter.id, {
@@ -92,15 +105,37 @@ export const SearchToolbar = ({
             selectedLocationId,
           });
           const selectedOption = filter.options.find(({ id }) => id === selectedOptionId) ?? defaultOption;
+          const isOpen = openedFilterId === filter.id;
+          const isSelected = selectedOption.id !== defaultOption?.id;
 
           return (
-            <Dropdown key={filter.id}>
+            <Dropdown
+              key={filter.id}
+              onOpenChange={(nextIsOpen) => {
+                onFilterOpenChange(nextIsOpen ? filter.id : openedFilterId === filter.id ? null : openedFilterId);
+              }}
+              open={isOpen}
+            >
               <Dropdown.Trigger>
                 <Filter
-                  className="text-sm"
+                  className={cn(
+                    "cursor-pointer rounded-full text-sm transition-[background-color,border-color,color,box-shadow]",
+                    isOpen && !isSelected && "cursor-pointer text-foreground/70",
+                    isSelected && "border border-primary/35 bg-primary/10 shadow-[inset_0_0_0_1px_rgba(31,95,76,0.02)]",
+                  )}
                   label={selectedOption.label}
                   leftIcon={null}
-                  selected={selectedOption.id !== defaultOption?.id}
+                  rightIcon={
+                    <ChevronDown
+                      className={cn(
+                        "transition-transform duration-200 ease-out motion-reduce:transition-none",
+                        isSelected && "text-primary",
+                        isOpen && "rotate-180",
+                      )}
+                      strokeWidth={1.8}
+                    />
+                  }
+                  selected={isSelected}
                   size="small"
                 />
               </Dropdown.Trigger>

--- a/apps/web/src/features/space-search/ui/space-search-toolbar.tsx
+++ b/apps/web/src/features/space-search/ui/space-search-toolbar.tsx
@@ -1,5 +1,6 @@
 import { Dropdown, Filter, TabButton } from "@ui/components";
 import { ChevronDown } from "@ui/icons";
+import type { Dispatch, SetStateAction } from "react";
 
 import { cn } from "@/shared/lib/cn";
 
@@ -15,7 +16,7 @@ import type {
 interface SearchToolbarProps {
   categories: SearchCategory[];
   filters: SearchFilter[];
-  onFilterOpenChange: (filterId: SearchFilter["id"] | null) => void;
+  onFilterOpenChange: Dispatch<SetStateAction<SearchFilter["id"] | null>>;
   onCategoryChange: (categoryId: SearchCategory["id"]) => void;
   onDateSortChange: (dateSortId: SearchDateSortId) => void;
   onDeadlineSortChange: (deadlineSortId: SearchDeadlineSortId) => void;
@@ -112,7 +113,13 @@ export const SearchToolbar = ({
             <Dropdown
               key={filter.id}
               onOpenChange={(nextIsOpen) => {
-                onFilterOpenChange(nextIsOpen ? filter.id : openedFilterId === filter.id ? null : openedFilterId);
+                onFilterOpenChange((prevOpenedFilterId) => {
+                  if (nextIsOpen) {
+                    return filter.id;
+                  }
+
+                  return prevOpenedFilterId === filter.id ? null : prevOpenedFilterId;
+                });
               }}
               open={isOpen}
             >


### PR DESCRIPTION
## 📌 Summary

- 스페이스 찾기 페이지의 카드, 필터, 카테고리 탭, 좋아요 버튼, 스페이스 만들기 버튼 전반의 인터랙션을 정리했습니다.  
- hover/open/selected 위주의 상태 표현을 개선했습니다.
- close #189 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks

- 스페이스 카드에 호버 인터랙션과 쉐도우를 적용했습니다.
  - 호버 시 카드 전체가 살짝 위로 떠오르며, 이미지도 살짝 커지게 됩니다.

- 스페이스 만들기 버튼에 기본 쉐도우와 호버 인터랙션을 적용했습니다.
  - 호버 시 버튼이 살짝 위로 떠오릅니다.


- 카테고리 탭에 호버 반응과 선택 상태 표현을 적용했습니다. 
  - 호버 시 혹은 선택된 카테고리 탭의 경우 위로 살짝 떠오르게 됩니다.


- 필터에 열림 상태 표현과 선택 상태 강조를 적용했습니다.
  - 필터가 열리면 화살표 아이콘이 회전하도록 적용했습니다.
  - 선택된 필터는 배경 강조가 보이도록 적용했습니다.


- 좋아요 버튼에 호버 인터랙션을 적용했습니다.
  - 호버 시 살짝 커지게 됩니다. 추후 가능하면 좋아요 클릭 시 애니메이션 구현하겠습니다.(후순위)

- 무한스크롤 하단 상태 UI를 추가했습니다.
  - 다음 페이지를 불러오는 동안 카드형 스켈레톤이 노출됩니다.
  - 더 불러올 결과가 없을 때 종료 문구가 노출됩니다
  - 
## 👀 To Reviewer

- 최대한 과하지 않게 적용하려고 노력하긴 했지만, 카드, 필터, 카테고리 탭, 좋아요 버튼의 인터랙션이 자연스러운지 확인 부탁드립니다.
- 필터 선택 시 초록색으로 배경 강조하는거 괜찮은지 판단 부탁드립니다.

## 📸 Screenshot

주요 변경점들입니다.

- 카드-호버 시(title 초록색. | 살짝 위로 떠오름)
<img width="999" height="505" alt="image" src="https://github.com/user-attachments/assets/f352bf8a-dc6a-4d75-b37a-f6f1e955008b" />

- 카테고리 탭(**왼쪽부터** 선택됨, hover, default. | 선택과 hover 시 위로 떠오름)
<img width="281" height="89" alt="image" src="https://github.com/user-attachments/assets/2109e559-5869-4526-bfb5-8e7ccf34a427" />

- 필터(옵션 선택된 필터에 초록 배경 강조, 필터 클릭 시 화살표 spin)
<img width="387" height="127" alt="image" src="https://github.com/user-attachments/assets/73a69613-c676-434f-871c-f453724ff6c6" />

- 무한 스크롤(스켈레톤, 더 이상 없을 경우엔 문구 | fetching은 더 일찍 시작되지만 네트워크가 느릴 경우 이미지처럼 스켈레톤이 다 보이게 내릴 수 있습니다.)
<img width="1311" height="821" alt="image" src="https://github.com/user-attachments/assets/a386050e-60e8-49e3-ac10-9cd883f1f822" />

<img width="1420" height="652" alt="image" src="https://github.com/user-attachments/assets/177c1b8b-0f46-4552-a844-5e89f8e1e8a6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 카드와 좋아요 버튼에 호버 확장 및 전환 애니메이션이 추가되어 시각적 반응이 향상되었습니다.
  * 카드 이미지 및 제목의 호버 스케일/색상 전환이 개선되었습니다.
  * 툴바 필터 트리거 아이콘 회전 및 카테고리 탭 스타일이 업데이트되었습니다.

* **개선**
  * 카드 레이아웃과 메타 정보 배치가 재구성되어 데스크톱/모바일 가독성이 향상되었고, 데스크톱에서는 좋아요 버튼 위치가 이동되었습니다.
  * 생성 버튼의 래퍼 및 스타일 적용 방식이 통일되어 일관된 동작을 제공합니다.
  * 필터 열림 상태를 외부에서 제어할 수 있게 되었고, 페이지네이션의 다음페이지 로딩 상태를 UI로 노출합니다.

* **신규**
  * 로딩용 카드 스켈레톤 컴포넌트와 페이징용 로딩 UI(로딩 안내 및 스켈레톤 표시)가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->