### PR TITLE
[fix] 찜한 모임 잘못된 스페이스 입장 버튼 노출 수정

### DIFF
--- a/apps/web/src/_pages/mypage/hooks/use-created-meetings.ts
+++ b/apps/web/src/_pages/mypage/hooks/use-created-meetings.ts
@@ -1,17 +1,18 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import type { CreatedFilterKey, MypageMoimCard } from "../model";
+import type { MypageMoimCard } from "../model";
 import { getCreatedMeetingCards } from "../use-cases";
 
-export const useCreatedMeetings = (
-  createdFilter: CreatedFilterKey,
-  initialData: MypageMoimCard[],
-  enabled: boolean,
-) => {
+interface UseCreatedMeetingsInitialData {
+  ended: MypageMoimCard[];
+  ongoing: MypageMoimCard[];
+}
+
+export const useCreatedMeetings = (initialData: UseCreatedMeetingsInitialData, enabled: boolean) => {
   return useQuery({
-    queryKey: ["mypage", "meetings", "created", createdFilter],
-    queryFn: () => getCreatedMeetingCards(createdFilter),
+    queryKey: ["mypage", "meetings", "created"],
+    queryFn: () => getCreatedMeetingCards(),
     initialData,
     staleTime: 0,
     enabled,

--- a/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
+++ b/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
@@ -50,16 +50,10 @@ export const useMypageViewState = ({
   });
 
   const {
-    data: ongoingCreatedMeetingCards = createdMoims.ongoing,
-    isError: isOngoingCreatedError,
-    refetch: refetchOngoingCreatedMeetings,
-  } = useCreatedMeetings("ongoing", createdMoims.ongoing, shouldFetchCreatedMeetings);
-
-  const {
-    data: endedCreatedMeetingCards = createdMoims.ended,
-    isError: isEndedCreatedError,
-    refetch: refetchEndedCreatedMeetings,
-  } = useCreatedMeetings("ended", createdMoims.ended, shouldFetchCreatedMeetings);
+    data: createdMeetingCards = createdMoims,
+    isError: isCreatedError,
+    refetch: refetchCreatedMeetings,
+  } = useCreatedMeetings(createdMoims, shouldFetchCreatedMeetings);
 
   const {
     data: favoriteList,
@@ -81,13 +75,13 @@ export const useMypageViewState = ({
   );
 
   const ongoingCreatedMeetings = useMemo(
-    () => applyFavoriteState(ongoingCreatedMeetingCards, favoriteMeetingIds),
-    [favoriteMeetingIds, ongoingCreatedMeetingCards],
+    () => applyFavoriteState(createdMeetingCards.ongoing, favoriteMeetingIds),
+    [createdMeetingCards.ongoing, favoriteMeetingIds],
   );
 
   const endedCreatedMeetings = useMemo(
-    () => applyFavoriteState(endedCreatedMeetingCards, favoriteMeetingIds),
-    [endedCreatedMeetingCards, favoriteMeetingIds],
+    () => applyFavoriteState(createdMeetingCards.ended, favoriteMeetingIds),
+    [createdMeetingCards.ended, favoriteMeetingIds],
   );
 
   const createdMeetings = createdFilter === "ongoing" ? ongoingCreatedMeetings : endedCreatedMeetings;
@@ -163,13 +157,13 @@ export const useMypageViewState = ({
     likedMeetings,
     enterableMeetingIds,
     isJoinedError,
-    isCreatedError: createdFilter === "ongoing" ? isOngoingCreatedError : isEndedCreatedError,
+    isCreatedError,
     isLikedError,
     handleTabChange,
     handleToggleLike,
     handleEnterSpace,
     refetchJoinedMeetings,
-    refetchCreatedMeetings: createdFilter === "ongoing" ? refetchOngoingCreatedMeetings : refetchEndedCreatedMeetings,
+    refetchCreatedMeetings,
     refetchLikedMeetings,
     setCreatedFilter,
   };

--- a/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
+++ b/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
@@ -38,6 +38,7 @@ export const useMypageViewState = ({
   const [selectedTab, setSelectedTab] = useState<MypageTabKey>("joined");
   const [createdFilter, setCreatedFilter] = useState<CreatedFilterKey>("ongoing");
   const favoriteMutation = useToggleFavorite(enableRemoteFetch);
+  const shouldFetchCreatedMeetings = enableRemoteFetch && (selectedTab === "created" || selectedTab === "liked");
 
   const {
     data: joinedMeetingCards = moims.joined,
@@ -49,10 +50,16 @@ export const useMypageViewState = ({
   });
 
   const {
-    data: createdMeetingCards = createdMoims[createdFilter],
-    isError: isCreatedError,
-    refetch: refetchCreatedMeetings,
-  } = useCreatedMeetings(createdFilter, createdMoims[createdFilter], enableRemoteFetch && selectedTab === "created");
+    data: ongoingCreatedMeetingCards = createdMoims.ongoing,
+    isError: isOngoingCreatedError,
+    refetch: refetchOngoingCreatedMeetings,
+  } = useCreatedMeetings("ongoing", createdMoims.ongoing, shouldFetchCreatedMeetings);
+
+  const {
+    data: endedCreatedMeetingCards = createdMoims.ended,
+    isError: isEndedCreatedError,
+    refetch: refetchEndedCreatedMeetings,
+  } = useCreatedMeetings("ended", createdMoims.ended, shouldFetchCreatedMeetings);
 
   const {
     data: favoriteList,
@@ -73,25 +80,41 @@ export const useMypageViewState = ({
     [favoriteMeetingIds, joinedMeetingCards],
   );
 
-  const createdMeetings = useMemo(
-    () => applyFavoriteState(createdMeetingCards, favoriteMeetingIds),
-    [createdMeetingCards, favoriteMeetingIds],
+  const ongoingCreatedMeetings = useMemo(
+    () => applyFavoriteState(ongoingCreatedMeetingCards, favoriteMeetingIds),
+    [favoriteMeetingIds, ongoingCreatedMeetingCards],
   );
+
+  const endedCreatedMeetings = useMemo(
+    () => applyFavoriteState(endedCreatedMeetingCards, favoriteMeetingIds),
+    [endedCreatedMeetingCards, favoriteMeetingIds],
+  );
+
+  const createdMeetings = createdFilter === "ongoing" ? ongoingCreatedMeetings : endedCreatedMeetings;
 
   const likedMeetings = useMemo(
     () => buildLikedMeetings(enableRemoteFetch ? favoriteList : undefined, moims.liked, enableRemoteFetch),
     [enableRemoteFetch, favoriteList, moims.liked],
   );
 
-  const meetingMap = useMemo(() => {
-    return [...joinedMeetings, ...createdMeetings, ...likedMeetings].reduce((map, meeting) => {
-      if (!map.has(meeting.id)) {
-        map.set(meeting.id, meeting);
-      }
+  const enterableMeetingIds = useMemo(() => {
+    return new Set(
+      [...joinedMeetings, ...ongoingCreatedMeetings, ...endedCreatedMeetings].map((meeting) => meeting.id),
+    );
+  }, [endedCreatedMeetings, joinedMeetings, ongoingCreatedMeetings]);
 
-      return map;
-    }, new Map<string, MypageMoimCard>());
-  }, [createdMeetings, joinedMeetings, likedMeetings]);
+  const meetingMap = useMemo(() => {
+    return [...joinedMeetings, ...ongoingCreatedMeetings, ...endedCreatedMeetings, ...likedMeetings].reduce(
+      (map, meeting) => {
+        if (!map.has(meeting.id)) {
+          map.set(meeting.id, meeting);
+        }
+
+        return map;
+      },
+      new Map<string, MypageMoimCard>(),
+    );
+  }, [endedCreatedMeetings, joinedMeetings, likedMeetings, ongoingCreatedMeetings]);
 
   const handleTabChange = (tab: string) => {
     if (!isMypageTabKey(tab)) {
@@ -138,14 +161,15 @@ export const useMypageViewState = ({
     joinedMeetings,
     createdMeetings,
     likedMeetings,
+    enterableMeetingIds,
     isJoinedError,
-    isCreatedError,
+    isCreatedError: createdFilter === "ongoing" ? isOngoingCreatedError : isEndedCreatedError,
     isLikedError,
     handleTabChange,
     handleToggleLike,
     handleEnterSpace,
     refetchJoinedMeetings,
-    refetchCreatedMeetings,
+    refetchCreatedMeetings: createdFilter === "ongoing" ? refetchOngoingCreatedMeetings : refetchEndedCreatedMeetings,
     refetchLikedMeetings,
     setCreatedFilter,
   };

--- a/apps/web/src/_pages/mypage/ui/moim-card-list.tsx
+++ b/apps/web/src/_pages/mypage/ui/moim-card-list.tsx
@@ -10,6 +10,8 @@ interface MoimCardListProps {
   onRetry?: () => void;
   onToggleLike?: (meetingId: string) => void;
   onEnterSpace?: (meetingId: string) => void;
+  showActionButton?: boolean;
+  canShowActionButton?: (moim: MypageMoimCard) => boolean;
 }
 
 interface ListStatusContainerProps {
@@ -31,12 +33,20 @@ export const MoimCardList = ({
   onRetry,
   onToggleLike,
   onEnterSpace,
+  showActionButton = true,
+  canShowActionButton,
 }: MoimCardListProps) => {
   if (moims.length > 0) {
     return (
       <div className="flex flex-col items-start gap-6">
         {moims.map((moim) => (
-          <MoimCard key={moim.id} moim={moim} onToggleLike={onToggleLike} onEnterSpace={onEnterSpace} />
+          <MoimCard
+            key={moim.id}
+            moim={moim}
+            onToggleLike={onToggleLike}
+            onEnterSpace={onEnterSpace}
+            showActionButton={canShowActionButton ? canShowActionButton(moim) : showActionButton}
+          />
         ))}
       </div>
     );

--- a/apps/web/src/_pages/mypage/ui/moim-card.tsx
+++ b/apps/web/src/_pages/mypage/ui/moim-card.tsx
@@ -10,6 +10,7 @@ interface MoimCardProps {
   moim: MypageMoimCard;
   onToggleLike?: (meetingId: string) => void;
   onEnterSpace?: (meetingId: string) => void;
+  showActionButton?: boolean;
 }
 
 const imageToneClassName: Record<MoimImageTone, string> = {
@@ -76,7 +77,7 @@ const MoimPreview = ({ imageTone, imageUrl, className }: MoimPreviewProps) => {
   );
 };
 
-export const MoimCard = ({ moim, onToggleLike, onEnterSpace }: MoimCardProps) => {
+export const MoimCard = ({ moim, onToggleLike, onEnterSpace, showActionButton = true }: MoimCardProps) => {
   const actionVariant = moim.actionVariant === "primary" ? "primary" : "secondary";
 
   const handleToggleLike = () => {
@@ -140,13 +141,13 @@ export const MoimCard = ({ moim, onToggleLike, onEnterSpace }: MoimCardProps) =>
           </div>
         </div>
 
-        {renderActionButton("mt-auto h-12 min-w-[9.75rem] self-end text-base md:hidden")}
+        {showActionButton ? renderActionButton("mt-auto h-12 min-w-[9.75rem] self-end text-base md:hidden") : null}
       </div>
 
       <div className="hidden items-center justify-between gap-4 md:ml-auto md:flex md:w-[11rem] md:flex-col md:items-end md:self-stretch">
         <HeartButton isLiked={moim.liked} onToggle={handleToggleLike} className="bg-card" />
 
-        {renderActionButton("h-12 min-w-[9.75rem] text-base")}
+        {showActionButton ? renderActionButton("h-12 min-w-[9.75rem] text-base") : null}
       </div>
     </article>
   );

--- a/apps/web/src/_pages/mypage/ui/mypage-view.tsx
+++ b/apps/web/src/_pages/mypage/ui/mypage-view.tsx
@@ -54,6 +54,8 @@ export function MypageView({
     enableRemoteFetch,
   });
 
+  const enterableMeetingIds = new Set([...joinedMeetings, ...createdMeetings].map((meeting) => meeting.id));
+
   return (
     <main className="no-scrollbar h-dvh overflow-y-auto bg-background-secondary px-4 py-8 text-foreground md:px-9 md:py-10 lg:px-8">
       <div className="mx-auto w-full max-w-[80rem]">
@@ -134,6 +136,7 @@ export function MypageView({
                   onRetry={() => void refetchLikedMeetings()}
                   onToggleLike={handleToggleLike}
                   onEnterSpace={handleEnterSpace}
+                  canShowActionButton={(moim) => enterableMeetingIds.has(moim.id)}
                 />
               </Tabs.Content>
             </div>

--- a/apps/web/src/_pages/mypage/ui/mypage-view.tsx
+++ b/apps/web/src/_pages/mypage/ui/mypage-view.tsx
@@ -37,6 +37,7 @@ export function MypageView({
     joinedMeetings,
     createdMeetings,
     likedMeetings,
+    enterableMeetingIds,
     isJoinedError,
     isCreatedError,
     isLikedError,
@@ -53,8 +54,6 @@ export function MypageView({
     createdMoims,
     enableRemoteFetch,
   });
-
-  const enterableMeetingIds = new Set([...joinedMeetings, ...createdMeetings].map((meeting) => meeting.id));
 
   return (
     <main className="no-scrollbar h-dvh overflow-y-auto bg-background-secondary px-4 py-8 text-foreground md:px-9 md:py-10 lg:px-8">

--- a/apps/web/src/_pages/mypage/use-cases/get-created-meeting-cards.ts
+++ b/apps/web/src/_pages/mypage/use-cases/get-created-meeting-cards.ts
@@ -1,6 +1,11 @@
-import { type CreatedFilterKey, fetchMyMeetings, type MypageMoimCard, mapCreatedMeeting } from "../model";
+import { fetchMyMeetings, type MypageMoimCard, mapCreatedMeeting } from "../model";
 
 const CREATED_MEETINGS_PAGE_SIZE = 100;
+
+interface CreatedMeetingCards {
+  ended: MypageMoimCard[];
+  ongoing: MypageMoimCard[];
+}
 
 const isCompletedMeeting = (dateTime: string | null) => {
   if (!dateTime) {
@@ -10,15 +15,29 @@ const isCompletedMeeting = (dateTime: string | null) => {
   return new Date(dateTime).getTime() < Date.now();
 };
 
-const getComparableTime = (dateTime: string | null, createdFilter: CreatedFilterKey) => {
+const getComparableTime = (dateTime: string | null, isOngoingMeeting: boolean) => {
   if (!dateTime) {
-    return createdFilter === "ongoing" ? Number.MAX_SAFE_INTEGER : Number.MIN_SAFE_INTEGER;
+    return isOngoingMeeting ? Number.MAX_SAFE_INTEGER : Number.MIN_SAFE_INTEGER;
   }
 
   return new Date(dateTime).getTime();
 };
 
-export const getCreatedMeetingCards = async (createdFilter: CreatedFilterKey): Promise<MypageMoimCard[]> => {
+const mapCreatedMeetings = (
+  meetings: Awaited<ReturnType<typeof fetchMyMeetings<"created">>>["data"],
+  isOngoingMeeting: boolean,
+) => {
+  return meetings
+    .sort((left, right) => {
+      const leftTime = getComparableTime(left.dateTime, isOngoingMeeting);
+      const rightTime = getComparableTime(right.dateTime, isOngoingMeeting);
+
+      return isOngoingMeeting ? leftTime - rightTime : rightTime - leftTime;
+    })
+    .map((meeting, index) => mapCreatedMeeting(meeting, index));
+};
+
+export const getCreatedMeetingCards = async (): Promise<CreatedMeetingCards> => {
   const response = await fetchMyMeetings({
     type: "created",
     sortBy: "dateTime",
@@ -26,17 +45,11 @@ export const getCreatedMeetingCards = async (createdFilter: CreatedFilterKey): P
     size: CREATED_MEETINGS_PAGE_SIZE,
   });
 
-  const isCreatedOngoing = createdFilter === "ongoing";
-  const filteredMeetings = response.data
-    .filter((meeting) =>
-      isCreatedOngoing ? !isCompletedMeeting(meeting.dateTime) : isCompletedMeeting(meeting.dateTime),
-    )
-    .sort((left, right) => {
-      const leftTime = getComparableTime(left.dateTime, createdFilter);
-      const rightTime = getComparableTime(right.dateTime, createdFilter);
+  const ongoingMeetings = response.data.filter((meeting) => !isCompletedMeeting(meeting.dateTime));
+  const endedMeetings = response.data.filter((meeting) => isCompletedMeeting(meeting.dateTime));
 
-      return isCreatedOngoing ? leftTime - rightTime : rightTime - leftTime;
-    });
-
-  return filteredMeetings.map((meeting, index) => mapCreatedMeeting(meeting, index));
+  return {
+    ongoing: mapCreatedMeetings(ongoingMeetings, true),
+    ended: mapCreatedMeetings(endedMeetings, false),
+  };
 };

--- a/apps/web/src/_pages/mypage/use-cases/toggle-favorite.ts
+++ b/apps/web/src/_pages/mypage/use-cases/toggle-favorite.ts
@@ -12,8 +12,23 @@ interface ToggleFavoriteMutationParams {
   nextLiked: boolean;
 }
 
+interface CreatedMeetingsCache {
+  ended: MypageMoimCard[];
+  ongoing: MypageMoimCard[];
+}
+
 const findMeetingLiked = (meetings: MypageMoimCard[] | undefined, meetingId: string) => {
   return meetings?.find((meeting) => meeting.id === meetingId)?.liked;
+};
+
+const findCreatedMeetingLiked = (meetings: CreatedMeetingsCache | undefined, meetingId: string) => {
+  const ongoingLiked = findMeetingLiked(meetings?.ongoing, meetingId);
+
+  if (ongoingLiked !== undefined) {
+    return ongoingLiked;
+  }
+
+  return findMeetingLiked(meetings?.ended, meetingId);
 };
 
 const restoreLikedState = (
@@ -26,6 +41,36 @@ const restoreLikedState = (
   }
 
   return meetings?.map((meeting) => (meeting.id === meetingId ? { ...meeting, liked: previousLiked } : meeting));
+};
+
+const updateCreatedMeetingsLikedState = (
+  meetings: CreatedMeetingsCache | undefined,
+  meetingId: string,
+  nextLiked: boolean,
+) => {
+  if (!meetings) {
+    return meetings;
+  }
+
+  return {
+    ongoing: updateLikedState(meetings.ongoing, meetingId, nextLiked) ?? meetings.ongoing,
+    ended: updateLikedState(meetings.ended, meetingId, nextLiked) ?? meetings.ended,
+  };
+};
+
+const restoreCreatedMeetingsLikedState = (
+  meetings: CreatedMeetingsCache | undefined,
+  meetingId: string,
+  previousLiked: boolean | undefined,
+) => {
+  if (!meetings) {
+    return meetings;
+  }
+
+  return {
+    ongoing: restoreLikedState(meetings.ongoing, meetingId, previousLiked) ?? meetings.ongoing,
+    ended: restoreLikedState(meetings.ended, meetingId, previousLiked) ?? meetings.ended,
+  };
 };
 
 const restoreFavoriteItem = (
@@ -86,24 +131,12 @@ export const useToggleFavorite = (enableRemoteFetch: boolean) => {
       // 진행 중인 refetch 응답이 optimistic state를 덮어쓰지 않도록 먼저 취소합니다.
       await Promise.all([
         queryClient.cancelQueries({ queryKey: ["mypage", "meetings", "joined"] }),
-        queryClient.cancelQueries({ queryKey: ["mypage", "meetings", "created", "ongoing"] }),
-        queryClient.cancelQueries({ queryKey: ["mypage", "meetings", "created", "ended"] }),
+        queryClient.cancelQueries({ queryKey: ["mypage", "meetings", "created"] }),
         queryClient.cancelQueries({ queryKey: ["mypage", "favorites"] }),
       ]);
 
       const previousJoined = queryClient.getQueryData<MypageMoimCard[]>(["mypage", "meetings", "joined"]);
-      const previousCreatedOngoing = queryClient.getQueryData<MypageMoimCard[]>([
-        "mypage",
-        "meetings",
-        "created",
-        "ongoing",
-      ]);
-      const previousCreatedEnded = queryClient.getQueryData<MypageMoimCard[]>([
-        "mypage",
-        "meetings",
-        "created",
-        "ended",
-      ]);
+      const previousCreated = queryClient.getQueryData<CreatedMeetingsCache>(["mypage", "meetings", "created"]);
       const previousFavorites = queryClient.getQueryData<FavoriteList>(["mypage", "favorites"]);
       const previousFavoriteIndex =
         previousFavorites?.data.findIndex((favorite) => favorite.meetingId === meetingId) ?? -1;
@@ -112,11 +145,8 @@ export const useToggleFavorite = (enableRemoteFetch: boolean) => {
       queryClient.setQueryData<MypageMoimCard[]>(["mypage", "meetings", "joined"], (current) =>
         updateLikedState(current, meetingIdString, nextLiked),
       );
-      queryClient.setQueryData<MypageMoimCard[]>(["mypage", "meetings", "created", "ongoing"], (current) =>
-        updateLikedState(current, meetingIdString, nextLiked),
-      );
-      queryClient.setQueryData<MypageMoimCard[]>(["mypage", "meetings", "created", "ended"], (current) =>
-        updateLikedState(current, meetingIdString, nextLiked),
+      queryClient.setQueryData<CreatedMeetingsCache>(["mypage", "meetings", "created"], (current) =>
+        updateCreatedMeetingsLikedState(current, meetingIdString, nextLiked),
       );
 
       if (!nextLiked) {
@@ -133,8 +163,7 @@ export const useToggleFavorite = (enableRemoteFetch: boolean) => {
       return {
         requestVersion,
         previousJoinedLiked: findMeetingLiked(previousJoined, meetingIdString),
-        previousCreatedOngoingLiked: findMeetingLiked(previousCreatedOngoing, meetingIdString),
-        previousCreatedEndedLiked: findMeetingLiked(previousCreatedEnded, meetingIdString),
+        previousCreatedLiked: findCreatedMeetingLiked(previousCreated, meetingIdString),
         previousFavorite,
         previousFavoriteIndex,
       };
@@ -179,11 +208,8 @@ export const useToggleFavorite = (enableRemoteFetch: boolean) => {
       queryClient.setQueryData<MypageMoimCard[]>(["mypage", "meetings", "joined"], (current) =>
         restoreLikedState(current, meetingIdString, context.previousJoinedLiked),
       );
-      queryClient.setQueryData<MypageMoimCard[]>(["mypage", "meetings", "created", "ongoing"], (current) =>
-        restoreLikedState(current, meetingIdString, context.previousCreatedOngoingLiked),
-      );
-      queryClient.setQueryData<MypageMoimCard[]>(["mypage", "meetings", "created", "ended"], (current) =>
-        restoreLikedState(current, meetingIdString, context.previousCreatedEndedLiked),
+      queryClient.setQueryData<CreatedMeetingsCache>(["mypage", "meetings", "created"], (current) =>
+        restoreCreatedMeetingsLikedState(current, meetingIdString, context.previousCreatedLiked),
       );
       queryClient.setQueryData<FavoriteList>(["mypage", "favorites"], (current) =>
         restoreFavoriteItem(current, context.previousFavorite, context.previousFavoriteIndex, variables.meetingId),


### PR DESCRIPTION
## 📌 Summary

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- close #195 
- 마이페이지 찜한 모임 탭에서 실제로 스페이스에 진입할 수 없는 모임에도 스페이스 입장 버튼이 노출되던 문제를 수정했습니다.
- joined 또는 created 목록에 포함된, 즉 현재 기준상 스페이스 진입 가능하다고 판단되는 모임에만 버튼이 보이도록 조건을 분리했습니다.

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- MoimCard에 액션 버튼 표시 여부를 제어할 수 있도록 분기 추가
- MoimCardList에서 카드별 버튼 노출 조건을 받을 수 있도록 확장
- 찜한 모임 탭에서 joined/created 목록에 포함된 모임만 스페이스 입장 버튼이 노출되도록 수정

## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

-찜한 모임 탭에서 버튼이 보여야 하는 기준을 joined/created 포함 여부로 잡은 방향이 적절한지 확인 부탁드립니다.

## 📸 Screenshot

_작업한 내용에 대한 스크린샷을 첨부해주세요._


<img width="1440" height="778" alt="스크린샷 2026-04-09 오후 1 51 36" src="https://github.com/user-attachments/assets/b05d256d-b4a7-4d96-b8c8-c0f9d80667b0" />

<img width="1440" height="804" alt="스크린샷 2026-04-09 오후 1 51 58" src="https://github.com/user-attachments/assets/d56c0a48-4de0-4885-8d98-31f2f7c1142b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지 그룹 카드의 작업 버튼 표시를 더 유연하게 제어할 수 있습니다 (기본 표시).
  * 각 카드별로 작업 버튼 표시 여부를 개별 판단할 수 있습니다.
  * 좋아요 탭에서는 사용자가 실제로 입장 가능한 그룹에만 작업 버튼이 표시됩니다.
* **리팩터**
  * 생성한 모임 데이터를 진행/종료로 분리하여 항상 두 집합을 제공하고, 관련 상태와 캐시 처리를 단순화했습니다.
  * 내부 상태에 입장 가능한 그룹 ID 집합이 추가되어 UI 결정에 사용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->