### PR TITLE
[refactor] next.config images.formats 명시

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -12,6 +12,7 @@ const nextConfig: NextConfig = {
     compilationMode: "annotation",
   },
   images: {
+    formats: ["image/avif", "image/webp"],
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## 📌 Summary

next.config의 images.formats를 `["image/avif", "image/webp"]`로 명시해 이미지 포맷 우선순위를 설정했습니다.

- close #188

## 📄 Tasks

- images.formats: ["image/avif", "image/webp"] 추가
- 로컬/프로덕션 환경에서 /_next/image 응답 헤더(Content-Type) 확인

## 👀 To Reviewer

- [Issue](https://github.com/sprint-13/moum-zip/issues/188)

> WebP: PNG/JPEG 대비 용량이 작은 경우가 많고, 브라우저 지원이 넓음
> AVIF: WebP보다 더 작은 용량이 나오는 경우가 많지만, 일부(특히 구형) 브라우저는 미지원
> (지원 브라우저에선 AVIF 우선, 미지원이면 WebP로 폴백)

## 📸 Screenshot

AVIF 미적용 케이스 → image/webp 응답
<img width="820" height="685" alt="스크린샷 2026-04-09 오후 4 45 09" src="https://github.com/user-attachments/assets/7df1dc65-b8e3-45d8-8708-9c16e8dd9397" />

AVIF 적용 케이스 → image/avif 응답
<img width="798" height="672" alt="스크린샷 2026-04-09 오후 4 54 20" src="https://github.com/user-attachments/assets/9304be28-4004-4427-a4e5-f8fd8f2cbb26" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 웹 애플리케이션의 이미지 최적화를 위해 추가 이미지 형식 지원이 활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->