### PR TITLE
[feat] 스페이스 내부 잔디 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ storybook-static
 .claude
 CLAUDE.md
 *.pen
+subagent-runs/

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,7 @@ storybook-static
 .claude
 CLAUDE.md
 *.pen
+
+# Codex subagent artifacts
 subagent-runs/
+subagent-*

--- a/apps/web/src/_pages/schedule/actions.ts
+++ b/apps/web/src/_pages/schedule/actions.ts
@@ -18,8 +18,9 @@ function invalidateSchedule(spaceId: string, slug: string) {
   revalidatePath(`/${slug}`); // 대시보드 일정 위젯 반영
 }
 
-function invalidateAttendance(spaceId: string, slug: string) {
-  updateTag(CACHE_TAGS.attendance(spaceId));
+function invalidateAttendance(spaceId: string, userId: number, slug: string) {
+  updateTag(CACHE_TAGS.grass(spaceId, userId));
+  updateTag(CACHE_TAGS.attendance(spaceId, userId));
   revalidatePath(`/${slug}`); // 대시보드 출석 현황 반영
 }
 
@@ -93,5 +94,5 @@ export async function deleteScheduleAction(slug: string, scheduleId: string) {
 export async function checkAttendanceAction(slug: string) {
   const { space, membership } = await getSpaceContext(slug).catch(handleAppError);
   await checkAttendanceUseCase(space.spaceId, membership.userId);
-  invalidateAttendance(space.spaceId, slug);
+  invalidateAttendance(space.spaceId, membership.userId, slug);
 }

--- a/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
+++ b/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
@@ -76,13 +76,14 @@ export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassS
                   <div key={week[0]?.date ?? "empty-week"} className="grid grid-rows-7 gap-1">
                     {week.map((day) => {
                       const isToday = day.date === todayDateKey;
+                      const cellLabel = getGrassCellLabel(day, isToday);
 
                       return (
                         <div
                           key={day.date}
                           role="img"
-                          title={getGrassCellLabel(day, isToday)}
-                          aria-label={getGrassCellLabel(day, isToday)}
+                          title={cellLabel}
+                          aria-label={cellLabel}
                           className={cn(
                             "h-3.5 w-3.5 cursor-help rounded-[4px] border transition-colors transition-transform duration-150 motion-safe:hover:-translate-y-0.5 motion-safe:hover:scale-110",
                             getGrassCellClassName(day.intensity),

--- a/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
+++ b/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
@@ -1,0 +1,102 @@
+import { SpaceCard } from "@/features/space";
+import { getGrassUseCase } from "@/features/space/use-cases/get-member-grass";
+import { cn } from "@/shared/lib/cn";
+
+interface DashboardGrassSectionProps {
+  spaceId: string;
+  userId: number;
+}
+
+const WEEK_COLUMN_SIZE = 7;
+
+export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassSectionProps) => {
+  const grass = await getGrassUseCase(spaceId, userId);
+  const weekColumns = chunkWeekColumns(grass.days);
+
+  return (
+    <SpaceCard>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-0.5">
+          <h3 className="font-bold text-base">활동 잔디</h3>
+          <p className="text-muted-foreground text-sm">최근 12주 동안의 스페이스 활동이에요.</p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <div className="rounded-lg bg-primary/10 px-3 py-2">
+            <p className="text-muted-foreground text-xs">연속 활동일</p>
+            <p className="font-semibold text-base">{grass.summary.currentStreak}일</p>
+          </div>
+          <div className="rounded-lg bg-primary/10 px-3 py-2">
+            <p className="text-muted-foreground text-xs">최근 7일 점수</p>
+            <p className="font-semibold text-base">{grass.summary.recentScore}점</p>
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <div className="flex min-w-fit gap-1.5">
+            {weekColumns.map((week) => (
+              <div key={week[0]?.date ?? "empty-week"} className="grid grid-rows-7 gap-1">
+                {week.map((day) => (
+                  <div
+                    key={day.date}
+                    role="img"
+                    title={formatDayLabel(day)}
+                    aria-label={formatDayLabel(day)}
+                    className={cn(
+                      "h-3.5 w-3.5 rounded-[4px] border transition-colors",
+                      getGrassCellClassName(day.intensity),
+                    )}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between text-muted-foreground text-xs">
+          <span>활동일 {grass.summary.activeDays}일</span>
+          <div className="flex items-center gap-1.5">
+            <span>적음</span>
+            {[0, 1, 2, 3, 4].map((intensity) => (
+              <div key={intensity} className={cn("h-3 w-3 rounded-[3px] border", getGrassCellClassName(intensity))} />
+            ))}
+            <span>많음</span>
+          </div>
+        </div>
+      </div>
+    </SpaceCard>
+  );
+};
+
+const chunkWeekColumns = <T,>(items: T[]) => {
+  return Array.from({ length: Math.ceil(items.length / WEEK_COLUMN_SIZE) }, (_, index) =>
+    items.slice(index * WEEK_COLUMN_SIZE, (index + 1) * WEEK_COLUMN_SIZE),
+  );
+};
+
+const getGrassCellClassName = (intensity: number) => {
+  switch (intensity) {
+    case 4:
+      return "border-primary bg-primary";
+    case 3:
+      return "border-primary/70 bg-primary/70";
+    case 2:
+      return "border-primary/45 bg-primary/45";
+    case 1:
+      return "border-primary/20 bg-primary/20";
+    default:
+      return "border-border/60 bg-muted/60";
+  }
+};
+
+const formatDayLabel = (day: {
+  date: string;
+  score: number;
+  postCount: number;
+  commentCount: number;
+  attendanceCount: number;
+}) => {
+  const attendanceLabel = day.attendanceCount > 0 ? "출석함" : "출석 없음";
+
+  return `${day.date} · ${day.score}점 · 게시글 ${day.postCount}개 · 댓글 ${day.commentCount}개 · ${attendanceLabel}`;
+};

--- a/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
+++ b/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
@@ -1,3 +1,4 @@
+import { getTodayKST } from "@/entities/schedule";
 import { SpaceCard } from "@/features/space";
 import { getGrassUseCase } from "@/features/space/use-cases/get-member-grass";
 import { cn } from "@/shared/lib/cn";
@@ -8,10 +9,14 @@ interface DashboardGrassSectionProps {
 }
 
 const WEEK_COLUMN_SIZE = 7;
+const WEEKDAY_LABEL_ROW_INDEXES = new Set([0, 2, 4]);
 
 export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassSectionProps) => {
   const grass = await getGrassUseCase(spaceId, userId);
+  const todayDateKey = getTodayKST();
   const weekColumns = chunkWeekColumns(grass.days);
+  const monthLabels = getMonthLabels(weekColumns);
+  const weekdayLabels = getWeekdayLabels(weekColumns);
 
   return (
     <SpaceCard>
@@ -33,29 +38,55 @@ export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassS
         </div>
 
         <div className="overflow-x-auto">
-          <div className="flex min-w-fit gap-1.5">
-            {weekColumns.map((week) => (
-              <div key={week[0]?.date ?? "empty-week"} className="grid grid-rows-7 gap-1">
-                {week.map((day) => (
-                  <div
-                    key={day.date}
-                    role="img"
-                    title={formatDayLabel(day)}
-                    aria-label={formatDayLabel(day)}
-                    className={cn(
-                      "h-3.5 w-3.5 rounded-[4px] border transition-colors",
-                      getGrassCellClassName(day.intensity),
-                    )}
-                  />
-                ))}
-              </div>
-            ))}
+          <div className="grid min-w-fit grid-cols-[auto_1fr] gap-x-2 gap-y-1.5">
+            <div />
+            <div className="flex gap-1.5 text-[10px] text-muted-foreground">
+              {monthLabels.map(({ label, key }) => (
+                <span key={key} className="w-3.5 whitespace-nowrap">
+                  {label}
+                </span>
+              ))}
+            </div>
+
+            <div className="grid grid-rows-7 gap-1 text-[10px] text-muted-foreground">
+              {weekdayLabels.map(({ key, label }) => (
+                <span key={key} className="flex h-3.5 items-center">
+                  {label}
+                </span>
+              ))}
+            </div>
+
+            <div className="flex gap-1.5 py-0.5">
+              {weekColumns.map((week) => (
+                <div key={week[0]?.date ?? "empty-week"} className="grid grid-rows-7 gap-1">
+                  {week.map((day) => {
+                    const isToday = day.date === todayDateKey;
+
+                    return (
+                      <div
+                        key={day.date}
+                        role="img"
+                        title={getGrassCellLabel(day, isToday)}
+                        aria-label={getGrassCellLabel(day, isToday)}
+                        className={cn(
+                          "h-3.5 w-3.5 rounded-[4px] border transition-colors",
+                          getGrassCellClassName(day.intensity),
+                          isToday && "ring-1 ring-primary/60 ring-offset-1 ring-offset-background",
+                        )}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
 
         <div className="flex items-center justify-between text-muted-foreground text-xs">
           <span>활동일 {grass.summary.activeDays}일</span>
           <div className="flex items-center gap-1.5">
+            <div className="h-3 w-3 rounded-[3px] border border-primary/40 bg-muted/90 ring-1 ring-primary/60 ring-offset-1 ring-offset-background" />
+            <span>오늘</span>
             <span>적음</span>
             {[0, 1, 2, 3, 4].map((intensity) => (
               <div key={intensity} className={cn("h-3 w-3 rounded-[3px] border", getGrassCellClassName(intensity))} />
@@ -72,6 +103,42 @@ const chunkWeekColumns = <T,>(items: T[]) => {
   return Array.from({ length: Math.ceil(items.length / WEEK_COLUMN_SIZE) }, (_, index) =>
     items.slice(index * WEEK_COLUMN_SIZE, (index + 1) * WEEK_COLUMN_SIZE),
   );
+};
+
+const getMonthLabels = (weekColumns: Array<Array<{ date: string }>>) => {
+  let previousMonth = "";
+
+  return weekColumns.map((week) => {
+    const date = week[0]?.date ?? "";
+    const month = date ? formatMonthLabel(date) : "";
+    const label = month !== previousMonth ? month : "";
+    previousMonth = month;
+
+    return {
+      key: date || month,
+      label,
+    };
+  });
+};
+
+const getWeekdayLabels = (weekColumns: Array<Array<{ date: string }>>) => {
+  const firstWeek = weekColumns[0] ?? [];
+
+  return Array.from({ length: WEEK_COLUMN_SIZE }, (_, index) => {
+    const date = firstWeek[index]?.date;
+
+    if (!date || !WEEKDAY_LABEL_ROW_INDEXES.has(index)) {
+      return {
+        key: `empty-${index}`,
+        label: "",
+      };
+    }
+
+    return {
+      key: date,
+      label: formatWeekdayLabel(date),
+    };
+  });
 };
 
 const getGrassCellClassName = (intensity: number) => {
@@ -100,3 +167,30 @@ const formatDayLabel = (day: {
 
   return `${day.date} · ${day.score}점 · 게시글 ${day.postCount}개 · 댓글 ${day.commentCount}개 · ${attendanceLabel}`;
 };
+
+const getGrassCellLabel = (
+  day: {
+    date: string;
+    score: number;
+    postCount: number;
+    commentCount: number;
+    attendanceCount: number;
+  },
+  isToday = false,
+) => {
+  const baseLabel = formatDayLabel(day);
+
+  return isToday ? `${baseLabel} · 오늘` : baseLabel;
+};
+
+const formatMonthLabel = (date: string) => {
+  const targetDate = parseDateKey(date);
+
+  return `${targetDate.getMonth() + 1}월`;
+};
+
+const formatWeekdayLabel = (date: string) => {
+  return new Intl.DateTimeFormat("ko-KR", { weekday: "short", timeZone: "Asia/Seoul" }).format(parseDateKey(date));
+};
+
+const parseDateKey = (date: string) => new Date(`${date}T00:00:00+09:00`);

--- a/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
+++ b/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
@@ -135,13 +135,13 @@ const getMonthLabels = (weekColumns: Array<Array<{ date: string }>>) => {
   let previousMonth = "";
 
   return weekColumns.map((week) => {
-    const date = week[0]?.date ?? "";
-    const month = date ? formatMonthLabel(date) : "";
+    const anchorDate = week.find(({ date }) => date.endsWith("-01"))?.date ?? week[0]?.date ?? "";
+    const month = anchorDate ? formatMonthLabel(anchorDate) : "";
     const label = month !== previousMonth ? month : "";
     previousMonth = month;
 
     return {
-      key: date || month,
+      key: anchorDate || month,
       label,
     };
   });

--- a/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
+++ b/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
@@ -97,7 +97,7 @@ export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassS
           <span>활동한 날 {grass.summary.activeDays}일</span>
           <div className="flex flex-wrap items-center gap-1.5 md:justify-end">
             <div className="h-3 w-3 rounded-[3px] border border-primary/40 bg-muted/90 ring-1 ring-primary/60 ring-offset-1 ring-offset-background" />
-            <span>오늘</span>
+            <span className="pr-2">: 오늘</span>
             <span>적음</span>
             {[0, 1, 2, 3, 4].map((intensity) => (
               <div key={intensity} className={cn("h-3 w-3 rounded-[3px] border", getGrassCellClassName(intensity))} />

--- a/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
+++ b/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
@@ -19,6 +19,14 @@ interface GrassDayLike {
 
 const WEEK_COLUMN_SIZE = 7;
 const WEEKDAY_LABEL_ROW_INDEXES = new Set([0, 2, 4]);
+const GRASS_LEGEND_ITEMS = [
+  { intensity: 0, label: "0" },
+  { intensity: 1, label: "1" },
+  { intensity: 2, label: "2" },
+  { intensity: 3, label: "3" },
+  { intensity: 5, label: "5" },
+  { intensity: 7, label: "7+" },
+] as const;
 
 export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassSectionProps) => {
   const grass = await getGrassUseCase(spaceId, userId);
@@ -30,9 +38,10 @@ export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassS
   return (
     <SpaceCard>
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-0.5">
+        <div className="flex flex-col gap-1">
           <h3 className="font-bold text-base">활동 잔디</h3>
           <p className="text-muted-foreground text-sm">최근 12주 동안의 스페이스 활동이에요.</p>
+          <p className="text-[11px] text-muted-foreground">게시글 2점 · 댓글 1점 · 출석 1점</p>
         </div>
 
         <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
@@ -79,7 +88,7 @@ export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassS
                           title={getGrassCellLabel(day, isToday)}
                           aria-label={getGrassCellLabel(day, isToday)}
                           className={cn(
-                            "h-3.5 w-3.5 rounded-[4px] border transition-colors",
+                            "h-3.5 w-3.5 cursor-help rounded-[4px] border transition-colors transition-transform duration-150 motion-safe:hover:-translate-y-0.5 motion-safe:hover:scale-110",
                             getGrassCellClassName(day.intensity),
                             isToday && "ring-1 ring-primary/60 ring-offset-1 ring-offset-background",
                           )}
@@ -93,16 +102,26 @@ export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassS
           </div>
         </div>
 
-        <div className="flex flex-col gap-2 text-muted-foreground text-xs md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-3 text-muted-foreground text-xs md:flex-row md:items-end md:justify-between">
           <span>활동한 날 {grass.summary.activeDays}일</span>
-          <div className="flex flex-wrap items-center gap-1.5 md:justify-end">
-            <div className="h-3 w-3 rounded-[3px] border border-primary/40 bg-muted/90 ring-1 ring-primary/60 ring-offset-1 ring-offset-background" />
-            <span className="pr-2">: 오늘</span>
-            <span>적음</span>
-            {[0, 1, 2, 3, 4].map((intensity) => (
-              <div key={intensity} className={cn("h-3 w-3 rounded-[3px] border", getGrassCellClassName(intensity))} />
-            ))}
-            <span>많음</span>
+
+          <div className="flex flex-col gap-1.5 md:items-end">
+            <div className="flex items-center gap-1.5">
+              <div className="h-3 w-3 rounded-[3px] border border-primary/40 bg-muted/90 ring-1 ring-primary/60 ring-offset-1 ring-offset-background" />
+              <span>테두리: 오늘</span>
+            </div>
+
+            <div className="flex flex-col gap-1 md:items-end">
+              <span>활동 점수 기준</span>
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 md:justify-end">
+                {GRASS_LEGEND_ITEMS.map(({ intensity, label }) => (
+                  <div key={label} className="flex items-center gap-1">
+                    <div className={cn("h-3 w-3 rounded-[3px] border", getGrassCellClassName(intensity))} />
+                    <span>{label}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -154,8 +173,10 @@ const getWeekdayLabels = (weekColumns: Array<Array<{ date: string }>>) => {
 
 const getGrassCellClassName = (intensity: number) => {
   switch (intensity) {
-    case 4:
+    case 7:
       return "border-primary bg-primary";
+    case 5:
+      return "border-primary/90 bg-primary/85";
     case 3:
       return "border-primary/70 bg-primary/70";
     case 2:

--- a/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
+++ b/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
@@ -8,6 +8,15 @@ interface DashboardGrassSectionProps {
   userId: number;
 }
 
+interface GrassDayLike {
+  date: string;
+  score: number;
+  intensity: number;
+  postCount: number;
+  commentCount: number;
+  attendanceCount: number;
+}
+
 const WEEK_COLUMN_SIZE = 7;
 const WEEKDAY_LABEL_ROW_INDEXES = new Set([0, 2, 4]);
 
@@ -26,9 +35,9 @@ export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassS
           <p className="text-muted-foreground text-sm">최근 12주 동안의 스페이스 활동이에요.</p>
         </div>
 
-        <div className="grid grid-cols-2 gap-2">
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
           <div className="rounded-lg bg-primary/10 px-3 py-2">
-            <p className="text-muted-foreground text-xs">연속 활동일</p>
+            <p className="text-muted-foreground text-xs">현재 연속 활동</p>
             <p className="font-semibold text-base">{grass.summary.currentStreak}일</p>
           </div>
           <div className="rounded-lg bg-primary/10 px-3 py-2">
@@ -38,53 +47,55 @@ export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassS
         </div>
 
         <div className="overflow-x-auto">
-          <div className="grid min-w-fit grid-cols-[auto_1fr] gap-x-2 gap-y-1.5">
-            <div />
-            <div className="flex gap-1.5 text-[10px] text-muted-foreground">
-              {monthLabels.map(({ label, key }) => (
-                <span key={key} className="w-3.5 whitespace-nowrap">
-                  {label}
-                </span>
-              ))}
-            </div>
+          <div className="flex min-w-fit justify-center">
+            <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1.5">
+              <div />
+              <div className="flex gap-1.5 text-[9px] text-muted-foreground">
+                {monthLabels.map(({ label, key }) => (
+                  <span key={key} className="w-3.5 whitespace-nowrap leading-none">
+                    {label}
+                  </span>
+                ))}
+              </div>
 
-            <div className="grid grid-rows-7 gap-1 text-[10px] text-muted-foreground">
-              {weekdayLabels.map(({ key, label }) => (
-                <span key={key} className="flex h-3.5 items-center">
-                  {label}
-                </span>
-              ))}
-            </div>
+              <div className="grid grid-rows-7 gap-1 text-[10px] text-muted-foreground">
+                {weekdayLabels.map(({ key, label }) => (
+                  <span key={key} className="flex h-3.5 items-center">
+                    {label}
+                  </span>
+                ))}
+              </div>
 
-            <div className="flex gap-1.5 py-0.5">
-              {weekColumns.map((week) => (
-                <div key={week[0]?.date ?? "empty-week"} className="grid grid-rows-7 gap-1">
-                  {week.map((day) => {
-                    const isToday = day.date === todayDateKey;
+              <div className="flex gap-1.5 py-0.5">
+                {weekColumns.map((week) => (
+                  <div key={week[0]?.date ?? "empty-week"} className="grid grid-rows-7 gap-1">
+                    {week.map((day) => {
+                      const isToday = day.date === todayDateKey;
 
-                    return (
-                      <div
-                        key={day.date}
-                        role="img"
-                        title={getGrassCellLabel(day, isToday)}
-                        aria-label={getGrassCellLabel(day, isToday)}
-                        className={cn(
-                          "h-3.5 w-3.5 rounded-[4px] border transition-colors",
-                          getGrassCellClassName(day.intensity),
-                          isToday && "ring-1 ring-primary/60 ring-offset-1 ring-offset-background",
-                        )}
-                      />
-                    );
-                  })}
-                </div>
-              ))}
+                      return (
+                        <div
+                          key={day.date}
+                          role="img"
+                          title={getGrassCellLabel(day, isToday)}
+                          aria-label={getGrassCellLabel(day, isToday)}
+                          className={cn(
+                            "h-3.5 w-3.5 rounded-[4px] border transition-colors",
+                            getGrassCellClassName(day.intensity),
+                            isToday && "ring-1 ring-primary/60 ring-offset-1 ring-offset-background",
+                          )}
+                        />
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         </div>
 
-        <div className="flex items-center justify-between text-muted-foreground text-xs">
-          <span>활동일 {grass.summary.activeDays}일</span>
-          <div className="flex items-center gap-1.5">
+        <div className="flex flex-col gap-2 text-muted-foreground text-xs md:flex-row md:items-center md:justify-between">
+          <span>활동한 날 {grass.summary.activeDays}일</span>
+          <div className="flex flex-wrap items-center gap-1.5 md:justify-end">
             <div className="h-3 w-3 rounded-[3px] border border-primary/40 bg-muted/90 ring-1 ring-primary/60 ring-offset-1 ring-offset-background" />
             <span>오늘</span>
             <span>적음</span>
@@ -156,28 +167,15 @@ const getGrassCellClassName = (intensity: number) => {
   }
 };
 
-const formatDayLabel = (day: {
-  date: string;
-  score: number;
-  postCount: number;
-  commentCount: number;
-  attendanceCount: number;
-}) => {
-  const attendanceLabel = day.attendanceCount > 0 ? "출석함" : "출석 없음";
+const formatDayLabel = (
+  day: Pick<GrassDayLike, "date" | "score" | "postCount" | "commentCount" | "attendanceCount">,
+) => {
+  const attendanceLabel = day.attendanceCount > 0 ? "출석함" : "출석 안 함";
 
   return `${day.date} · ${day.score}점 · 게시글 ${day.postCount}개 · 댓글 ${day.commentCount}개 · ${attendanceLabel}`;
 };
 
-const getGrassCellLabel = (
-  day: {
-    date: string;
-    score: number;
-    postCount: number;
-    commentCount: number;
-    attendanceCount: number;
-  },
-  isToday = false,
-) => {
+const getGrassCellLabel = (day: GrassDayLike, isToday = false) => {
   const baseLabel = formatDayLabel(day);
 
   return isToday ? `${baseLabel} · 오늘` : baseLabel;

--- a/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
+++ b/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
@@ -18,7 +18,7 @@ interface GrassDayLike {
 }
 
 const WEEK_COLUMN_SIZE = 7;
-const WEEKDAY_LABEL_ROW_INDEXES = new Set([0, 2, 4]);
+const WEEKDAY_LABEL_ROW_INDEXES = new Set([0, 2, 4, 6]);
 const GRASS_LEGEND_ITEMS = [
   { intensity: 0, label: "0" },
   { intensity: 1, label: "1" },
@@ -44,7 +44,11 @@ export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassS
           <p className="text-[11px] text-muted-foreground">게시글 2점 · 댓글 1점 · 출석 1점</p>
         </div>
 
-        <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
+          <div className="rounded-lg bg-primary/15 px-3 py-2">
+            <p className="text-muted-foreground text-xs">오늘 점수</p>
+            <p className="font-semibold text-base">{grass.summary.todayScore}점</p>
+          </div>
           <div className="rounded-lg bg-primary/10 px-3 py-2">
             <p className="text-muted-foreground text-xs">현재 연속 활동</p>
             <p className="font-semibold text-base">{grass.summary.currentStreak}일</p>

--- a/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
+++ b/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
@@ -197,9 +197,9 @@ const getGrassCellLabel = (day: GrassDay, isToday = false) => {
 };
 
 const formatMonthLabel = (date: string) => {
-  const targetDate = parseDateKey(date);
+  const month = Number(date.slice(5, 7));
 
-  return `${targetDate.getMonth() + 1}월`;
+  return `${month}월`;
 };
 
 const formatWeekdayLabel = (date: string) => {

--- a/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
+++ b/apps/web/src/app/[space-slug]/_components/dashboard-grass-section.tsx
@@ -1,20 +1,11 @@
 import { getTodayKST } from "@/entities/schedule";
 import { SpaceCard } from "@/features/space";
-import { getGrassUseCase } from "@/features/space/use-cases/get-member-grass";
+import { type GrassDay, getGrassUseCase } from "@/features/space/use-cases/get-member-grass";
 import { cn } from "@/shared/lib/cn";
 
 interface DashboardGrassSectionProps {
   spaceId: string;
   userId: number;
-}
-
-interface GrassDayLike {
-  date: string;
-  score: number;
-  intensity: number;
-  postCount: number;
-  commentCount: number;
-  attendanceCount: number;
 }
 
 const WEEK_COLUMN_SIZE = 7;
@@ -27,6 +18,7 @@ const GRASS_LEGEND_ITEMS = [
   { intensity: 5, label: "5" },
   { intensity: 7, label: "7+" },
 ] as const;
+const weekdayFormatter = new Intl.DateTimeFormat("ko-KR", { weekday: "short", timeZone: "Asia/Seoul" });
 
 export const DashboardGrassSection = async ({ spaceId, userId }: DashboardGrassSectionProps) => {
   const grass = await getGrassUseCase(spaceId, userId);
@@ -192,15 +184,13 @@ const getGrassCellClassName = (intensity: number) => {
   }
 };
 
-const formatDayLabel = (
-  day: Pick<GrassDayLike, "date" | "score" | "postCount" | "commentCount" | "attendanceCount">,
-) => {
+const formatDayLabel = (day: Pick<GrassDay, "date" | "score" | "postCount" | "commentCount" | "attendanceCount">) => {
   const attendanceLabel = day.attendanceCount > 0 ? "출석함" : "출석 안 함";
 
   return `${day.date} · ${day.score}점 · 게시글 ${day.postCount}개 · 댓글 ${day.commentCount}개 · ${attendanceLabel}`;
 };
 
-const getGrassCellLabel = (day: GrassDayLike, isToday = false) => {
+const getGrassCellLabel = (day: GrassDay, isToday = false) => {
   const baseLabel = formatDayLabel(day);
 
   return isToday ? `${baseLabel} · 오늘` : baseLabel;
@@ -213,7 +203,7 @@ const formatMonthLabel = (date: string) => {
 };
 
 const formatWeekdayLabel = (date: string) => {
-  return new Intl.DateTimeFormat("ko-KR", { weekday: "short", timeZone: "Asia/Seoul" }).format(parseDateKey(date));
+  return weekdayFormatter.format(parseDateKey(date));
 };
 
 const parseDateKey = (date: string) => new Date(`${date}T00:00:00+09:00`);

--- a/apps/web/src/app/[space-slug]/page.tsx
+++ b/apps/web/src/app/[space-slug]/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { SpaceBody, SpaceBodyLeft, SpaceBodyRight, SpaceHeader } from "@/features/space";
 import { getSpaceContext } from "@/features/space/lib/get-space-context";
 import { DashboardAttendanceSection } from "./_components/dashboard-attendance-section";
+import { DashboardGrassSection } from "./_components/dashboard-grass-section";
 import { DashboardPostSection } from "./_components/dashboard-post-section";
 import { DashboardScheduleSection } from "./_components/dashboard-schedule-section";
 
@@ -24,6 +25,9 @@ export default async function SpacePage({ params }: { params: Promise<{ "space-s
         <SpaceBodyRight>
           <Suspense fallback={<DashboardAttendanceSkeleton />}>
             <DashboardAttendanceSection spaceId={space.spaceId} userId={membership.userId} slug={slug} />
+          </Suspense>
+          <Suspense fallback={<DashboardGrassSkeleton />}>
+            <DashboardGrassSection spaceId={space.spaceId} userId={membership.userId} />
           </Suspense>
         </SpaceBodyRight>
       </SpaceBody>
@@ -64,6 +68,27 @@ function DashboardAttendanceSkeleton() {
       </div>
       <div className="h-20 rounded-lg bg-muted" />
       <div className="h-11 rounded-lg bg-muted" />
+    </div>
+  );
+}
+
+function DashboardGrassSkeleton() {
+  return (
+    <div className="flex animate-pulse flex-col gap-4 rounded-lg border border-border bg-background p-5 shadow-sm">
+      <div className="flex flex-col gap-1.5">
+        <div className="h-5 w-20 rounded bg-muted" />
+        <div className="h-4 w-40 rounded bg-muted" />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="h-16 rounded-lg bg-muted" />
+        <div className="h-16 rounded-lg bg-muted" />
+      </div>
+      <div className="grid grid-cols-12 gap-1.5">
+        {Array.from({ length: 84 }).map((_, index) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: skeleton
+          <div key={index} className="h-3.5 w-3.5 rounded-[4px] bg-muted" />
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/api/spaces/[slug]/bulletin/[post-id]/comments/[comment-id]/route.ts
+++ b/apps/web/src/app/api/spaces/[slug]/bulletin/[post-id]/comments/[comment-id]/route.ts
@@ -1,9 +1,11 @@
+import { revalidatePath, revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { memberQueries } from "@/entities/member";
 import { spaceQueries } from "@/entities/spaces";
 import { deleteCommentUseCase } from "@/features/space/use-cases/delete-comment";
 import { updateCommentUseCase } from "@/features/space/use-cases/update-comment";
 import { isAuth } from "@/shared/api/server";
+import { CACHE_TAGS } from "@/shared/lib/cache";
 
 async function getAuthAndSpace(slug: string) {
   const auth = await isAuth();
@@ -58,7 +60,12 @@ export async function DELETE(
 
   const { membership } = result;
   try {
-    await deleteCommentUseCase(commentId, postId, { userId: membership.userId, role: membership.role });
+    const { authorId } = await deleteCommentUseCase(commentId, postId, {
+      userId: membership.userId,
+      role: membership.role,
+    });
+    revalidateTag(CACHE_TAGS.grass(result.space.id, authorId), { expire: 0 });
+    revalidatePath(`/${slug}`);
     return new NextResponse(null, { status: 204 });
   } catch (err) {
     console.error("[DELETE /api/.../comments/[comment-id]]", err);

--- a/apps/web/src/app/api/spaces/[slug]/bulletin/[post-id]/comments/route.ts
+++ b/apps/web/src/app/api/spaces/[slug]/bulletin/[post-id]/comments/route.ts
@@ -50,9 +50,13 @@ export async function POST(request: Request, { params }: { params: Promise<{ slu
   }
 
   const { auth, space } = result;
+  if (typeof auth.userId !== "number") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   try {
     const { content } = await request.json();
-    const authorId = auth.userId as number;
+    const authorId = auth.userId;
     const { commentId } = await createCommentUseCase({
       postId,
       spaceId: space.id,

--- a/apps/web/src/app/api/spaces/[slug]/bulletin/[post-id]/comments/route.ts
+++ b/apps/web/src/app/api/spaces/[slug]/bulletin/[post-id]/comments/route.ts
@@ -1,9 +1,11 @@
+import { revalidatePath, revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { memberQueries } from "@/entities/member";
 import { spaceQueries } from "@/entities/spaces";
 import { createCommentUseCase } from "@/features/space/use-cases/create-comment";
 import { getPostComments } from "@/features/space/use-cases/get-post-detail";
 import { isAuth } from "@/shared/api/server";
+import { CACHE_TAGS } from "@/shared/lib/cache";
 import { AppError } from "@/shared/lib/error";
 
 async function getAuthAndSpace(slug: string) {
@@ -50,12 +52,15 @@ export async function POST(request: Request, { params }: { params: Promise<{ slu
   const { auth, space } = result;
   try {
     const { content } = await request.json();
+    const authorId = auth.userId as number;
     const { commentId } = await createCommentUseCase({
       postId,
       spaceId: space.id,
-      authorId: auth.userId as number,
+      authorId,
       content,
     });
+    revalidateTag(CACHE_TAGS.grass(space.id, authorId), { expire: 0 });
+    revalidatePath(`/${slug}`);
     return NextResponse.json({ commentId }, { status: 201 });
   } catch (err) {
     if (err instanceof AppError && err.code === "POST_NOT_FOUND") {

--- a/apps/web/src/app/api/spaces/[slug]/bulletin/[post-id]/route.ts
+++ b/apps/web/src/app/api/spaces/[slug]/bulletin/[post-id]/route.ts
@@ -1,4 +1,4 @@
-import { updateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { memberQueries } from "@/entities/member";
 import type { PostCategory } from "@/entities/post";
@@ -58,7 +58,6 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ sl
       { postId, spaceId: space.id, title, content, category: category as PostCategory },
       { userId: membership.userId, role: membership.role },
     );
-    updateTag(CACHE_TAGS.bulletin(space.id));
     return NextResponse.json({ postId });
   } catch (err) {
     if (err instanceof AppError && err.code === "POST_NOT_FOUND") {
@@ -79,8 +78,12 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
 
   const { space, membership } = result;
   try {
-    await deletePostUseCase(postId, space.id, { userId: membership.userId, role: membership.role });
-    updateTag(CACHE_TAGS.bulletin(space.id));
+    const { authorId } = await deletePostUseCase(postId, space.id, {
+      userId: membership.userId,
+      role: membership.role,
+    });
+    revalidateTag(CACHE_TAGS.grass(space.id, authorId), { expire: 0 });
+    revalidatePath(`/${slug}`);
     return new NextResponse(null, { status: 204 });
   } catch (err) {
     if (err instanceof AppError && err.code === "POST_NOT_FOUND") {

--- a/apps/web/src/app/api/spaces/[slug]/bulletin/route.ts
+++ b/apps/web/src/app/api/spaces/[slug]/bulletin/route.ts
@@ -1,4 +1,4 @@
-import { updateTag } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 import { memberQueries } from "@/entities/member";
 import type { PostCategory } from "@/entities/post";
@@ -64,7 +64,8 @@ export async function POST(request: Request, { params }: { params: Promise<{ slu
       category: category as PostCategory,
       image,
     });
-    updateTag(CACHE_TAGS.bulletin(space.id));
+    revalidateTag(CACHE_TAGS.grass(space.id, auth.userId), { expire: 0 });
+    revalidatePath(`/${slug}`);
     return NextResponse.json({ postId }, { status: 201 });
   } catch (err) {
     console.error("[POST /api/spaces/[slug]/bulletin]", err);

--- a/apps/web/src/entities/post/queries.ts
+++ b/apps/web/src/entities/post/queries.ts
@@ -11,6 +11,10 @@ const authorFields = {
   image: spaceMembers.avatarUrl,
 };
 
+/** UTC timestamp를 KST 일자 문자열로 변환 */
+const createKstDateExpr = (column: typeof spacePosts.createdAt | typeof spacePostComments.createdAt) =>
+  sql<string>`to_char(timezone('Asia/Seoul', timezone('UTC', ${column})), 'YYYY-MM-DD')`;
+
 export const postQueries = {
   /** 게시글 목록 (작성자 포함) */
   findManyBySpaceId: (spaceId: string, opts?: { category?: PostCategory; limit?: number; offset?: number }) =>
@@ -114,6 +118,27 @@ export const postQueries = {
     return result[0]?.count ?? 0;
   },
 
+  /** 작성자 기준 최근 활동 일자별 게시글 수 집계 */
+  countByAuthorDateRange: async (
+    spaceId: string,
+    authorId: number,
+    startAt: Date,
+  ): Promise<Array<{ date: string; count: number }>> => {
+    const dateExpr = createKstDateExpr(spacePosts.createdAt);
+
+    return db
+      .select({
+        date: dateExpr,
+        count: count().mapWith(Number),
+      })
+      .from(spacePosts)
+      .where(
+        and(eq(spacePosts.spaceId, spaceId), eq(spacePosts.authorId, authorId), gte(spacePosts.createdAt, startAt)),
+      )
+      .groupBy(dateExpr)
+      .orderBy(dateExpr);
+  },
+
   /** 인기 게시글 (viewCount + likeCount*2 + commentCount*1.4 점수 내림차순) */
   findPopularBySpaceId: async (spaceId: string, limit = 3) => {
     return db
@@ -164,6 +189,31 @@ export const commentQueries = {
       .where(eq(spacePostComments.id, commentId))
       .returning()
       .then((rows) => rows[0]),
+
+  /** 작성자 기준 최근 활동 일자별 댓글 수 집계 */
+  countByAuthorDateRange: async (
+    spaceId: string,
+    authorId: number,
+    startAt: Date,
+  ): Promise<Array<{ date: string; count: number }>> => {
+    const dateExpr = createKstDateExpr(spacePostComments.createdAt);
+
+    return db
+      .select({
+        date: dateExpr,
+        count: count().mapWith(Number),
+      })
+      .from(spacePostComments)
+      .where(
+        and(
+          eq(spacePostComments.spaceId, spaceId),
+          eq(spacePostComments.authorId, authorId),
+          gte(spacePostComments.createdAt, startAt),
+        ),
+      )
+      .groupBy(dateExpr)
+      .orderBy(dateExpr);
+  },
 
   /** 댓글 생성 + 게시글 commentCount 증가 (트랜잭션) */
   create: async (input: { id: string; postId: string; spaceId: string; authorId: number; content: string }) => {

--- a/apps/web/src/entities/schedule/queries.ts
+++ b/apps/web/src/entities/schedule/queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, count, eq, gte } from "drizzle-orm";
 import { db } from "@/shared/db";
 import { attendances, schedules } from "@/shared/db/scheme";
 
@@ -50,6 +50,18 @@ export const attendanceQueries = {
     db.query.attendances.findFirst({
       where: and(eq(attendances.spaceId, spaceId), eq(attendances.userId, userId), eq(attendances.date, date)),
     }),
+
+  /** 유저 기준 최근 활동 일자별 출석 수 집계 */
+  countByUserDateRange: (spaceId: string, userId: number, startDate: string) =>
+    db
+      .select({
+        date: attendances.date,
+        count: count().mapWith(Number),
+      })
+      .from(attendances)
+      .where(and(eq(attendances.spaceId, spaceId), eq(attendances.userId, userId), gte(attendances.date, startDate)))
+      .groupBy(attendances.date)
+      .orderBy(asc(attendances.date)),
 
   /** 출석 체크 등록 */
   create: (input: { id: string; spaceId: string; userId: number; date: string }) =>

--- a/apps/web/src/features/space/use-cases/delete-comment.test.ts
+++ b/apps/web/src/features/space/use-cases/delete-comment.test.ts
@@ -35,7 +35,7 @@ describe("deleteCommentUseCase", () => {
     const result = await deleteCommentUseCase("comment-1", "post-1", { userId: 1, role: "member" });
 
     expect(mockDeleteById).toHaveBeenCalledWith("comment-1", "post-1");
-    expect(result).toEqual({ commentId: "comment-1" });
+    expect(result).toEqual({ commentId: "comment-1", authorId: 1 });
   });
 
   it("manager는 타인의 댓글을 삭제할 수 있다", async () => {
@@ -44,7 +44,7 @@ describe("deleteCommentUseCase", () => {
     const result = await deleteCommentUseCase("comment-1", "post-1", { userId: 1, role: "manager" });
 
     expect(mockDeleteById).toHaveBeenCalledWith("comment-1", "post-1");
-    expect(result).toEqual({ commentId: "comment-1" });
+    expect(result).toEqual({ commentId: "comment-1", authorId: 99 });
   });
 
   it("존재하지 않는 댓글 삭제 시 에러를 던진다", async () => {

--- a/apps/web/src/features/space/use-cases/delete-comment.ts
+++ b/apps/web/src/features/space/use-cases/delete-comment.ts
@@ -11,7 +11,7 @@ export async function deleteCommentUseCase(
   commentId: string,
   postId: string,
   requester: Requester,
-): Promise<{ commentId: string }> {
+): Promise<{ commentId: string; authorId: number }> {
   const comment = await commentQueries.findById(commentId);
   if (!comment) throw new Error("댓글을 찾을 수 없습니다.");
 
@@ -20,5 +20,5 @@ export async function deleteCommentUseCase(
   if (comment.postId !== postId) throw new Error("유효하지 않은 요청입니다.");
 
   await commentQueries.deleteById(commentId, postId);
-  return { commentId };
+  return { commentId, authorId: comment.authorId };
 }

--- a/apps/web/src/features/space/use-cases/delete-post.test.ts
+++ b/apps/web/src/features/space/use-cases/delete-post.test.ts
@@ -42,7 +42,7 @@ describe("deletePostUseCase", () => {
     const result = await deletePostUseCase("post-1", "space-1", { userId: 1, role: "member" });
 
     expect(mockDeleteById).toHaveBeenCalledWith("post-1");
-    expect(result).toEqual({ postId: "post-1" });
+    expect(result).toEqual({ postId: "post-1", authorId: 1 });
   });
 
   it("manager는 타인의 게시글을 삭제할 수 있다", async () => {
@@ -51,7 +51,7 @@ describe("deletePostUseCase", () => {
     const result = await deletePostUseCase("post-1", "space-1", { userId: 1, role: "manager" });
 
     expect(mockDeleteById).toHaveBeenCalledWith("post-1");
-    expect(result).toEqual({ postId: "post-1" });
+    expect(result).toEqual({ postId: "post-1", authorId: 99 });
   });
 
   it("존재하지 않는 게시글 삭제 시 AppError(POST_NOT_FOUND)를 던진다", async () => {

--- a/apps/web/src/features/space/use-cases/delete-post.ts
+++ b/apps/web/src/features/space/use-cases/delete-post.ts
@@ -11,7 +11,7 @@ export async function deletePostUseCase(
   postId: string,
   spaceId: string,
   requester: Requester,
-): Promise<{ postId: string }> {
+): Promise<{ postId: string; authorId: number }> {
   const rows = await postQueries.findById(postId);
   const post = rows[0]?.post;
   if (!post || post.spaceId !== spaceId) throw new AppError("POST_NOT_FOUND");
@@ -19,5 +19,5 @@ export async function deletePostUseCase(
   assertPermission(post.authorId, requester);
 
   await postQueries.deleteById(postId);
-  return { postId };
+  return { postId, authorId: post.authorId };
 }

--- a/apps/web/src/features/space/use-cases/get-member-grass.test.ts
+++ b/apps/web/src/features/space/use-cases/get-member-grass.test.ts
@@ -72,6 +72,7 @@ describe("getSpaceMemberGrassUseCase", () => {
       intensity: 5,
     });
     expect(result.summary).toEqual({
+      todayScore: 6,
       currentStreak: 3,
       recentScore: 10,
       activeDays: 3,
@@ -126,9 +127,30 @@ describe("getSpaceMemberGrassUseCase", () => {
     });
     expect(result.days.map((day) => day.date)).toEqual(["2026-04-07", "2026-04-08", "2026-04-09"]);
     expect(result.summary).toEqual({
+      todayScore: 2,
       currentStreak: 1,
       recentScore: 2,
       activeDays: 1,
+    });
+  });
+
+  it("오늘 활동이 없어도 가장 최근까지 이어진 streak를 계산한다", async () => {
+    repository.countPostsByDateRange.setRows([
+      { date: "2026-04-07", count: 1 },
+      { date: "2026-04-08", count: 1 },
+    ]);
+
+    const useCase = createGetGrassUseCase({
+      repository,
+      getTodayDateKey: () => "2026-04-09",
+    });
+    const result = await useCase("space-1", 7, { days: 3 });
+
+    expect(result.summary).toEqual({
+      todayScore: 0,
+      currentStreak: 2,
+      recentScore: 4,
+      activeDays: 2,
     });
   });
 });

--- a/apps/web/src/features/space/use-cases/get-member-grass.test.ts
+++ b/apps/web/src/features/space/use-cases/get-member-grass.test.ts
@@ -69,13 +69,45 @@ describe("getSpaceMemberGrassUseCase", () => {
       commentCount: 1,
       attendanceCount: 1,
       score: 6,
-      intensity: 4,
+      intensity: 5,
     });
     expect(result.summary).toEqual({
       currentStreak: 3,
       recentScore: 10,
       activeDays: 3,
     });
+  });
+
+  it("상위 점수 구간을 1, 2, 3, 5, 7 기준으로 나눈다", async () => {
+    repository.countPostsByDateRange.setRows([
+      { date: "2026-04-03", count: 1 },
+      { date: "2026-04-04", count: 1 },
+      { date: "2026-04-05", count: 1 },
+      { date: "2026-04-06", count: 2 },
+      { date: "2026-04-07", count: 3 },
+    ]);
+    repository.countCommentsByDateRange.setRows([
+      { date: "2026-04-04", count: 0 },
+      { date: "2026-04-05", count: 1 },
+      { date: "2026-04-06", count: 1 },
+      { date: "2026-04-07", count: 1 },
+    ]);
+    repository.countAttendancesByDateRange.setRows([
+      { date: "2026-04-03", count: 1 },
+      { date: "2026-04-06", count: 1 },
+    ]);
+
+    const useCase = createGetGrassUseCase({
+      repository,
+      getTodayDateKey: () => "2026-04-07",
+    });
+    const result = await useCase("space-1", 7, { days: 5 });
+
+    expect(result.days.find((day) => day.date === "2026-04-03")).toMatchObject({ score: 3, intensity: 3 });
+    expect(result.days.find((day) => day.date === "2026-04-04")).toMatchObject({ score: 2, intensity: 2 });
+    expect(result.days.find((day) => day.date === "2026-04-05")).toMatchObject({ score: 3, intensity: 3 });
+    expect(result.days.find((day) => day.date === "2026-04-06")).toMatchObject({ score: 6, intensity: 5 });
+    expect(result.days.find((day) => day.date === "2026-04-07")).toMatchObject({ score: 7, intensity: 7 });
   });
 
   it("days 옵션을 사용하면 더 짧은 기간으로 집계한다", async () => {

--- a/apps/web/src/features/space/use-cases/get-member-grass.test.ts
+++ b/apps/web/src/features/space/use-cases/get-member-grass.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createGetGrassUseCase } from "./get-member-grass";
+
+describe("getSpaceMemberGrassUseCase", () => {
+  let repository: {
+    countPostsByDateRange: ReturnType<typeof createCountStub>;
+    countCommentsByDateRange: ReturnType<typeof createCountStub>;
+    countAttendancesByDateRange: ReturnType<typeof createCountStub>;
+  };
+
+  beforeEach(() => {
+    repository = {
+      countPostsByDateRange: createCountStub(),
+      countCommentsByDateRange: createCountStub(),
+      countAttendancesByDateRange: createCountStub(),
+    };
+  });
+
+  it("84일 활동을 날짜별로 병합하고 요약값을 계산한다", async () => {
+    repository.countPostsByDateRange.setRows([
+      { date: "2026-04-07", count: 1 },
+      { date: "2026-04-09", count: 2 },
+    ]);
+    repository.countCommentsByDateRange.setRows([
+      { date: "2026-04-08", count: 2 },
+      { date: "2026-04-09", count: 1 },
+    ]);
+    repository.countAttendancesByDateRange.setRows([{ date: "2026-04-09", count: 1 }]);
+
+    const useCase = createGetGrassUseCase({
+      repository,
+      getTodayDateKey: () => "2026-04-09",
+    });
+    const result = await useCase("space-1", 7, { days: 84 });
+
+    expect(repository.countPostsByDateRange.calls[0]).toMatchObject({
+      spaceId: "space-1",
+      userId: 7,
+    });
+    expect(repository.countCommentsByDateRange.calls[0]).toMatchObject({
+      spaceId: "space-1",
+      userId: 7,
+    });
+    expect(repository.countAttendancesByDateRange.calls[0]).toEqual({
+      spaceId: "space-1",
+      userId: 7,
+      startDate: "2026-01-16",
+    });
+
+    expect(result.days).toHaveLength(84);
+    expect(result.days[0]?.date).toBe("2026-01-16");
+    expect(result.days.at(-1)?.date).toBe("2026-04-09");
+    expect(result.days.find((day) => day.date === "2026-04-07")).toMatchObject({
+      postCount: 1,
+      commentCount: 0,
+      attendanceCount: 0,
+      score: 2,
+      intensity: 2,
+    });
+    expect(result.days.find((day) => day.date === "2026-04-08")).toMatchObject({
+      postCount: 0,
+      commentCount: 2,
+      attendanceCount: 0,
+      score: 2,
+      intensity: 2,
+    });
+    expect(result.days.find((day) => day.date === "2026-04-09")).toMatchObject({
+      postCount: 2,
+      commentCount: 1,
+      attendanceCount: 1,
+      score: 6,
+      intensity: 4,
+    });
+    expect(result.summary).toEqual({
+      currentStreak: 3,
+      recentScore: 10,
+      activeDays: 3,
+    });
+  });
+
+  it("days 옵션을 사용하면 더 짧은 기간으로 집계한다", async () => {
+    repository.countPostsByDateRange.setRows([{ date: "2026-04-09", count: 1 }]);
+
+    const useCase = createGetGrassUseCase({
+      repository,
+      getTodayDateKey: () => "2026-04-09",
+    });
+    const result = await useCase("space-1", 7, { days: 3 });
+
+    expect(repository.countAttendancesByDateRange.calls[0]).toEqual({
+      spaceId: "space-1",
+      userId: 7,
+      startDate: "2026-04-07",
+    });
+    expect(result.days.map((day) => day.date)).toEqual(["2026-04-07", "2026-04-08", "2026-04-09"]);
+    expect(result.summary).toEqual({
+      currentStreak: 1,
+      recentScore: 2,
+      activeDays: 1,
+    });
+  });
+});
+
+const createCountStub = () => {
+  let rows: Array<{ date: string; count: number }> = [];
+  const calls: Array<{ spaceId: string; userId: number; startDate?: string; startAt?: Date }> = [];
+
+  const stub = async (spaceId: string, userId: number, rangeStart: string | Date) => {
+    calls.push(
+      rangeStart instanceof Date
+        ? { spaceId, userId, startAt: rangeStart }
+        : { spaceId, userId, startDate: rangeStart },
+    );
+
+    return rows;
+  };
+
+  return Object.assign(stub, {
+    calls,
+    setRows: (nextRows: Array<{ date: string; count: number }>) => {
+      rows = nextRows;
+    },
+  });
+};

--- a/apps/web/src/features/space/use-cases/get-member-grass.ts
+++ b/apps/web/src/features/space/use-cases/get-member-grass.ts
@@ -1,6 +1,8 @@
+import { cacheLife, cacheTag } from "next/cache";
 import { commentQueries, postQueries } from "@/entities/post/queries";
 import { getTodayKST } from "@/entities/schedule";
 import { attendanceQueries } from "@/entities/schedule/queries";
+import { CACHE_TAGS } from "@/shared/lib/cache";
 
 const DEFAULT_GRASS_DAYS = 84;
 const RECENT_SCORE_DAYS = 7;
@@ -74,7 +76,19 @@ export const createGetGrassUseCase =
     });
   };
 
-export const getGrassUseCase = createGetGrassUseCase();
+const getGrass = createGetGrassUseCase();
+
+export async function getGrassUseCase(
+  spaceId: string,
+  userId: number,
+  options: GetGrassOptions = {},
+): Promise<SpaceMemberGrass> {
+  "use cache";
+  cacheTag(CACHE_TAGS.grass(spaceId, userId));
+  cacheLife("hours");
+
+  return getGrass(spaceId, userId, options);
+}
 
 const buildGrass = (
   totalDays: number,

--- a/apps/web/src/features/space/use-cases/get-member-grass.ts
+++ b/apps/web/src/features/space/use-cases/get-member-grass.ts
@@ -159,7 +159,8 @@ const getCurrentStreak = (days: GrassDay[]) => {
   let latestActiveIndex = -1;
 
   for (let index = days.length - 1; index >= 0; index -= 1) {
-    if (days[index]?.score && days[index].score > 0) {
+    const day = days[index];
+    if (day && day.score > 0) {
       latestActiveIndex = index;
       break;
     }
@@ -172,7 +173,8 @@ const getCurrentStreak = (days: GrassDay[]) => {
   let streak = 0;
 
   for (let index = latestActiveIndex; index >= 0; index -= 1) {
-    if (days[index]?.score === 0) {
+    const day = days[index];
+    if (!day || day.score === 0) {
       break;
     }
 

--- a/apps/web/src/features/space/use-cases/get-member-grass.ts
+++ b/apps/web/src/features/space/use-cases/get-member-grass.ts
@@ -172,23 +172,27 @@ const getRecentScore = (days: GrassDay[]) => {
 };
 
 const getGrassIntensity = (score: number) => {
-  if (score <= 0) {
-    return 0;
+  if (score >= 7) {
+    return 7;
   }
 
-  if (score === 1) {
-    return 1;
+  if (score >= 5) {
+    return 5;
   }
 
-  if (score <= 3) {
-    return 2;
-  }
-
-  if (score <= 5) {
+  if (score >= 3) {
     return 3;
   }
 
-  return 4;
+  if (score >= 2) {
+    return 2;
+  }
+
+  if (score >= 1) {
+    return 1;
+  }
+
+  return 0;
 };
 
 const normalizeWindowDays = (days?: number) => {

--- a/apps/web/src/features/space/use-cases/get-member-grass.ts
+++ b/apps/web/src/features/space/use-cases/get-member-grass.ts
@@ -33,6 +33,7 @@ export interface GrassDay {
 }
 
 export interface GrassSummary {
+  todayScore: number;
   currentStreak: number;
   recentScore: number;
   activeDays: number;
@@ -131,6 +132,7 @@ const buildGrass = (
   return {
     days: normalizedDays,
     summary: {
+      todayScore: getTodayScore(normalizedDays),
       currentStreak: getCurrentStreak(normalizedDays),
       recentScore: getRecentScore(normalizedDays),
       activeDays: normalizedDays.filter((day) => day.score > 0).length,
@@ -154,9 +156,22 @@ const applyCounts = (
 };
 
 const getCurrentStreak = (days: GrassDay[]) => {
-  let streak = 0;
+  let latestActiveIndex = -1;
 
   for (let index = days.length - 1; index >= 0; index -= 1) {
+    if (days[index]?.score && days[index].score > 0) {
+      latestActiveIndex = index;
+      break;
+    }
+  }
+
+  if (latestActiveIndex < 0) {
+    return 0;
+  }
+
+  let streak = 0;
+
+  for (let index = latestActiveIndex; index >= 0; index -= 1) {
     if (days[index]?.score === 0) {
       break;
     }
@@ -165,6 +180,10 @@ const getCurrentStreak = (days: GrassDay[]) => {
   }
 
   return streak;
+};
+
+const getTodayScore = (days: GrassDay[]) => {
+  return days.at(-1)?.score ?? 0;
 };
 
 const getRecentScore = (days: GrassDay[]) => {

--- a/apps/web/src/features/space/use-cases/get-member-grass.ts
+++ b/apps/web/src/features/space/use-cases/get-member-grass.ts
@@ -1,0 +1,199 @@
+import { commentQueries, postQueries } from "@/entities/post/queries";
+import { getTodayKST } from "@/entities/schedule";
+import { attendanceQueries } from "@/entities/schedule/queries";
+
+const DEFAULT_GRASS_DAYS = 84;
+const RECENT_SCORE_DAYS = 7;
+
+interface GrassRepository {
+  countPostsByDateRange: (spaceId: string, userId: number, startAt: Date) => Promise<GrassCountByDateRow[]>;
+  countCommentsByDateRange: (spaceId: string, userId: number, startAt: Date) => Promise<GrassCountByDateRow[]>;
+  countAttendancesByDateRange: (spaceId: string, userId: number, startDate: string) => Promise<GrassCountByDateRow[]>;
+}
+
+interface GetGrassDeps {
+  repository?: GrassRepository;
+  getTodayDateKey?: () => string;
+}
+
+interface GrassCountByDateRow {
+  date: string;
+  count: number;
+}
+
+export interface GrassDay {
+  date: string;
+  score: number;
+  intensity: number;
+  postCount: number;
+  commentCount: number;
+  attendanceCount: number;
+}
+
+export interface GrassSummary {
+  currentStreak: number;
+  recentScore: number;
+  activeDays: number;
+}
+
+export interface SpaceMemberGrass {
+  days: GrassDay[];
+  summary: GrassSummary;
+}
+
+export interface GetGrassOptions {
+  days?: number;
+}
+
+const defaultGrassRepository: GrassRepository = {
+  countPostsByDateRange: (spaceId, userId, startAt) => postQueries.countByAuthorDateRange(spaceId, userId, startAt),
+  countCommentsByDateRange: (spaceId, userId, startAt) =>
+    commentQueries.countByAuthorDateRange(spaceId, userId, startAt),
+  countAttendancesByDateRange: (spaceId, userId, startDate) =>
+    attendanceQueries.countByUserDateRange(spaceId, userId, startDate),
+};
+
+export const createGetGrassUseCase =
+  ({ repository = defaultGrassRepository, getTodayDateKey = getTodayKST }: GetGrassDeps = {}) =>
+  async (spaceId: string, userId: number, options: GetGrassOptions = {}): Promise<SpaceMemberGrass> => {
+    const totalDays = normalizeWindowDays(options.days);
+    const today = getTodayDateKey();
+    const startDate = getDateKeyWithOffset(today, -(totalDays - 1));
+    const startAt = parseDateKey(startDate);
+
+    const [postCounts, commentCounts, attendanceCounts] = await Promise.all([
+      repository.countPostsByDateRange(spaceId, userId, startAt),
+      repository.countCommentsByDateRange(spaceId, userId, startAt),
+      repository.countAttendancesByDateRange(spaceId, userId, startDate),
+    ]);
+
+    return buildGrass(totalDays, startDate, {
+      postCounts,
+      commentCounts,
+      attendanceCounts,
+    });
+  };
+
+export const getGrassUseCase = createGetGrassUseCase();
+
+const buildGrass = (
+  totalDays: number,
+  startDate: string,
+  counts: {
+    postCounts: GrassCountByDateRow[];
+    commentCounts: GrassCountByDateRow[];
+    attendanceCounts: GrassCountByDateRow[];
+  },
+): SpaceMemberGrass => {
+  const days = Array.from({ length: totalDays }, (_, index) => {
+    const date = getDateKeyWithOffset(startDate, index);
+
+    return {
+      date,
+      score: 0,
+      intensity: 0,
+      postCount: 0,
+      commentCount: 0,
+      attendanceCount: 0,
+    } satisfies GrassDay;
+  });
+
+  const dayMap = new Map(days.map((day) => [day.date, day]));
+
+  applyCounts(dayMap, counts.postCounts, "postCount");
+  applyCounts(dayMap, counts.commentCounts, "commentCount");
+  applyCounts(dayMap, counts.attendanceCounts, "attendanceCount");
+
+  const normalizedDays = days.map((day) => {
+    const score = day.postCount * 2 + day.commentCount + day.attendanceCount;
+
+    return {
+      ...day,
+      score,
+      intensity: getGrassIntensity(score),
+    };
+  });
+
+  return {
+    days: normalizedDays,
+    summary: {
+      currentStreak: getCurrentStreak(normalizedDays),
+      recentScore: getRecentScore(normalizedDays),
+      activeDays: normalizedDays.filter((day) => day.score > 0).length,
+    },
+  };
+};
+
+const applyCounts = (
+  dayMap: Map<string, GrassDay>,
+  rows: GrassCountByDateRow[],
+  key: "postCount" | "commentCount" | "attendanceCount",
+) => {
+  rows.forEach(({ date, count: dailyCount }) => {
+    const day = dayMap.get(date);
+    if (!day) {
+      return;
+    }
+
+    day[key] = dailyCount;
+  });
+};
+
+const getCurrentStreak = (days: GrassDay[]) => {
+  let streak = 0;
+
+  for (let index = days.length - 1; index >= 0; index -= 1) {
+    if (days[index]?.score === 0) {
+      break;
+    }
+
+    streak += 1;
+  }
+
+  return streak;
+};
+
+const getRecentScore = (days: GrassDay[]) => {
+  return days.slice(-RECENT_SCORE_DAYS).reduce((sum, day) => sum + day.score, 0);
+};
+
+const getGrassIntensity = (score: number) => {
+  if (score <= 0) {
+    return 0;
+  }
+
+  if (score === 1) {
+    return 1;
+  }
+
+  if (score <= 3) {
+    return 2;
+  }
+
+  if (score <= 5) {
+    return 3;
+  }
+
+  return 4;
+};
+
+const normalizeWindowDays = (days?: number) => {
+  if (!days || Number.isNaN(days)) {
+    return DEFAULT_GRASS_DAYS;
+  }
+
+  return Math.max(1, Math.floor(days));
+};
+
+const getDateKeyWithOffset = (date: string, amount: number) => {
+  const nextDate = parseDateKey(date);
+  nextDate.setDate(nextDate.getDate() + amount);
+
+  return formatDateKey(nextDate);
+};
+
+const parseDateKey = (date: string) => new Date(`${date}T00:00:00+09:00`);
+
+const formatDateKey = (date: Date) => {
+  return new Intl.DateTimeFormat("sv-SE", { timeZone: "Asia/Seoul" }).format(date);
+};

--- a/apps/web/src/shared/db/scheme.ts
+++ b/apps/web/src/shared/db/scheme.ts
@@ -1,5 +1,5 @@
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
-import { date, integer, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { date, index, integer, pgTable, text, timestamp, unique } from "drizzle-orm/pg-core";
 
 export const spaces = pgTable("spaces", {
   id: text("id").primaryKey(),
@@ -39,39 +39,47 @@ export type Member = InferSelectModel<typeof spaceMembers>;
 // 2. 삽입용 (Insert) 타입: 데이터를 넣을 때 쓰는 모양 (id, joinedAt 등 기본값이 있는 필드는 선택사항이 됨)
 export type NewMember = InferInsertModel<typeof spaceMembers>;
 
-export const spacePosts = pgTable("space_posts", {
-  id: text("id").primaryKey(),
-  spaceId: text("space_id")
-    .notNull()
-    .references(() => spaces.id),
-  authorId: integer("author_id").notNull(),
-  category: text("category", { enum: ["notice", "discussion", "question", "material"] }).notNull(),
-  title: text("title").notNull(),
-  content: text("content").notNull(),
-  image: text("image"),
-  viewCount: integer("view_count").notNull().default(0),
-  likeCount: integer("like_count").notNull().default(0),
-  commentCount: integer("comment_count").notNull().default(0),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
-});
+export const spacePosts = pgTable(
+  "space_posts",
+  {
+    id: text("id").primaryKey(),
+    spaceId: text("space_id")
+      .notNull()
+      .references(() => spaces.id),
+    authorId: integer("author_id").notNull(),
+    category: text("category", { enum: ["notice", "discussion", "question", "material"] }).notNull(),
+    title: text("title").notNull(),
+    content: text("content").notNull(),
+    image: text("image"),
+    viewCount: integer("view_count").notNull().default(0),
+    likeCount: integer("like_count").notNull().default(0),
+    commentCount: integer("comment_count").notNull().default(0),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow(),
+  },
+  (table) => [index("space_posts_space_author_created_idx").on(table.spaceId, table.authorId, table.createdAt)],
+);
 
 export type SpacePost = InferSelectModel<typeof spacePosts>;
 export type NewSpacePost = InferInsertModel<typeof spacePosts>;
 
-export const spacePostComments = pgTable("space_post_comments", {
-  id: text("id").primaryKey(),
-  postId: text("post_id")
-    .notNull()
-    .references(() => spacePosts.id, { onDelete: "cascade" }),
-  spaceId: text("space_id")
-    .notNull()
-    .references(() => spaces.id),
-  authorId: integer("author_id").notNull(),
-  content: text("content").notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
-});
+export const spacePostComments = pgTable(
+  "space_post_comments",
+  {
+    id: text("id").primaryKey(),
+    postId: text("post_id")
+      .notNull()
+      .references(() => spacePosts.id, { onDelete: "cascade" }),
+    spaceId: text("space_id")
+      .notNull()
+      .references(() => spaces.id),
+    authorId: integer("author_id").notNull(),
+    content: text("content").notNull(),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow(),
+  },
+  (table) => [index("space_post_comments_space_author_created_idx").on(table.spaceId, table.authorId, table.createdAt)],
+);
 
 export type SpacePostComment = InferSelectModel<typeof spacePostComments>;
 export type NewSpacePostComment = InferInsertModel<typeof spacePostComments>;

--- a/apps/web/src/shared/lib/cache.ts
+++ b/apps/web/src/shared/lib/cache.ts
@@ -3,6 +3,7 @@ export const CACHE_TAGS = {
   members: (spaceId: string) => `members-${spaceId}`,
   member: (spaceId: string, userId: number) => `member-${spaceId}-${userId}`,
   bulletin: (spaceId: string) => `bulletin-${spaceId}`,
+  grass: (spaceId: string, userId: number) => `grass-${spaceId}-${userId}`,
   schedule: (spaceId: string) => `schedule-${spaceId}`,
   attendance: (spaceId: string, userId?: number) =>
     userId ? `attendance-${spaceId}-${userId}` : `attendance-${spaceId}`,


### PR DESCRIPTION
## 📌 Summary

스페이스 대시보드에 개인 활동 잔디 기능을 추가했습니다.  
최근 84일 기준으로 게시글, 댓글, 출석 활동을 집계해 히트맵으로 보여주고, 오늘 점수와 연속 활동 현황까지 함께 확인할 수 있도록 구성했습니다.

- close #194

## 📄 Tasks

- 스페이스 멤버의 최근 84일 (12주) 활동을 집계하는 잔디 조회 유즈케이스 추가
- 게시글 2점, 댓글 1점, 출석 1점 기준의 활동 점수 규칙 반영
- 활동 점수에 기반하여 잔디 강도 버킷을 `1 / 2 / 3 / 5 / 7+` 기준으로 구성
- 스페이스 대시보드 우측 컬럼에 잔디 카드 UI 추가
- 상단 요약 정보에 `오늘 점수`, `현재 연속 활동`, `최근 7일 점수` 노출
- 오늘 활동이 없을 때는 최근 활동일까지의 streak를, 오늘 활동이 생기면 오늘까지의 streak를 보여주는 연속 활동정책 반영
- 스페이스 테마 색상에 맞춰 잔디 셀 색상이 함께 바뀌도록 연동
- 게시글 작성/삭제, 댓글 작성/삭제, 출석 체크 이후 잔디 캐시가 갱신되도록 연동
- 잔디 집계 조회 성능 보완을 위해, 실제 조회 조건인 `spaceId + authorId + 최근 createdAt 범위`에 맞춰 게시글/댓글 테이블에 아래 복합 인덱스를 추가했습니다.
  - `space_posts (space_id, author_id, created_at)`
  - `space_post_comments (space_id, author_id, created_at)`
- 게시글/댓글 집계 쿼리는 DB에서 `EXPLAIN ANALYZE`로 확인 결과 아직 데이터 규모가 작아 `Seq Scan`을 선택하고 있지만, 데이터가 증가하거나 집계 기간이 확장되면 해당 조건에서 더 효율적으로 동작할 수 있도록 미리 반영했습니다.
## 👀 To Reviewer

- 너무 깃허브랑 똑같은 것 같긴 한데 좀 개성있게 바꿀까요? ex)진짜 잔디처럼 애니메이션추가
- 최근 12주간의 집계 기간이 UI상 너무 짧진 않은가요? 더 늘려도 될 것 같습니다.
- 대시보드에서 잔디 카드의 위치와 밀도가 기존 스페이스 UI 흐름에 자연스러운지 확인 부탁드립니다.

## 📸 Screenshot

- 기본 잔디 전체
<img width="1365" height="852" alt="image" src="https://github.com/user-attachments/assets/3c1f16d4-c446-4be9-8e40-657f4a1f5a24" />

- 위 사진에서 출석체크버튼 클릭 시

<img width="358" height="408" alt="image" src="https://github.com/user-attachments/assets/1b8576e9-9d69-4647-aa2e-62e9712814c0" />

- 테마별 잔디 색상 변화
<img width="1360" height="843" alt="image" src="https://github.com/user-attachments/assets/2e5676dd-43f6-4feb-ac79-f1e759e4353d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 활동 기록(Grass) 대시보드 추가: 히트맵, 당일/연속/7일 요약, 툴팁·접근성, 스켈레톤 로딩 지원
* **버그 수정 / 동기화 개선**
  * 댓글·게시글·참여 생성/수정/삭제 시 사용자별 활동 캐시와 페이지 즉시 재검증하여 대시보드 반영 지연 감소
* **테스트**
  * 활동 집계 및 삭제 관련 단위 테스트 추가/기대값 갱신
* **기타**
  * 활동 집계용 DB 인덱스·사용자별 캐시 키 추가, .gitignore 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->