### PR TITLE
[fix] 마이페이지 참여 상태 표시 기준 수정

### DIFF
--- a/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
+++ b/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
@@ -12,6 +12,7 @@ import {
   applyFavoriteState,
   buildFavoriteMeetingIds,
   buildLikedMeetings,
+  mergeEnterableLikedMeetings,
   useToggleFavorite,
 } from "@/_pages/mypage/use-cases";
 
@@ -90,8 +91,24 @@ export const useMypageViewState = ({
 
   const likedMeetings = useMemo(
     () =>
-      buildLikedMeetings(enableRemoteFetch ? favoriteList : undefined, moims.liked, enableRemoteFetch, profile.userId),
-    [enableRemoteFetch, favoriteList, moims.liked, profile.userId],
+      mergeEnterableLikedMeetings(
+        buildLikedMeetings(
+          enableRemoteFetch ? favoriteList : undefined,
+          moims.liked,
+          enableRemoteFetch,
+          profile.userId,
+        ),
+        [...joinedMeetings, ...ongoingCreatedMeetings, ...endedCreatedMeetings],
+      ),
+    [
+      enableRemoteFetch,
+      endedCreatedMeetings,
+      favoriteList,
+      joinedMeetings,
+      moims.liked,
+      ongoingCreatedMeetings,
+      profile.userId,
+    ],
   );
 
   const enterableMeetingIds = useMemo(() => {
@@ -139,6 +156,7 @@ export const useMypageViewState = ({
     favoriteMutation.mutate({
       meetingId: Number(meetingId),
       nextLiked: !meeting.liked,
+      currentUserId: profile.userId,
     });
   };
 

--- a/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
+++ b/apps/web/src/_pages/mypage/hooks/use-mypage-view-state.ts
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { getSpaceSlugAction } from "@/_pages/mypage/actions";
 import { useCreatedMeetings } from "@/_pages/mypage/hooks/use-created-meetings";
-import type { CreatedFilterKey, MypageMoimCard, MypageTabKey } from "@/_pages/mypage/model";
+import type { CreatedFilterKey, MypageMoimCard, MypageProfile, MypageTabKey } from "@/_pages/mypage/model";
 import { getFavoritesQueryOptions, getJoinedMeetingsQueryOptions } from "@/_pages/mypage/queries";
 import {
   applyFavoriteState,
@@ -22,6 +22,7 @@ interface UseMypageViewStateParams {
   moims: Record<MoimTabKey, MypageMoimCard[]>;
   createdMoims: Record<CreatedFilterKey, MypageMoimCard[]>;
   enableRemoteFetch: boolean;
+  profile: MypageProfile;
 }
 
 const isMypageTabKey = (tab: string): tab is MypageTabKey => {
@@ -33,6 +34,7 @@ export const useMypageViewState = ({
   moims,
   createdMoims,
   enableRemoteFetch,
+  profile,
 }: UseMypageViewStateParams) => {
   const router = useRouter();
   const [selectedTab, setSelectedTab] = useState<MypageTabKey>("joined");
@@ -45,7 +47,7 @@ export const useMypageViewState = ({
     isError: isJoinedError,
     refetch: refetchJoinedMeetings,
   } = useQuery({
-    ...getJoinedMeetingsQueryOptions(moims.joined),
+    ...getJoinedMeetingsQueryOptions(moims.joined, profile.userId),
     enabled: enableRemoteFetch && selectedTab === "joined",
   });
 
@@ -87,8 +89,9 @@ export const useMypageViewState = ({
   const createdMeetings = createdFilter === "ongoing" ? ongoingCreatedMeetings : endedCreatedMeetings;
 
   const likedMeetings = useMemo(
-    () => buildLikedMeetings(enableRemoteFetch ? favoriteList : undefined, moims.liked, enableRemoteFetch),
-    [enableRemoteFetch, favoriteList, moims.liked],
+    () =>
+      buildLikedMeetings(enableRemoteFetch ? favoriteList : undefined, moims.liked, enableRemoteFetch, profile.userId),
+    [enableRemoteFetch, favoriteList, moims.liked, profile.userId],
   );
 
   const enterableMeetingIds = useMemo(() => {

--- a/apps/web/src/_pages/mypage/mock-data.ts
+++ b/apps/web/src/_pages/mypage/mock-data.ts
@@ -1,6 +1,7 @@
 import type { CreatedFilterKey, MypageMoimCard, MypageProfile, MypageTabKey } from "./model/types";
 
 export const profileMockData: MypageProfile = {
+  userId: 1,
   name: "럽윈즈올",
   email: "lovewins@codeit.com",
 };

--- a/apps/web/src/_pages/mypage/model/mappers.test.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.test.ts
@@ -325,7 +325,7 @@ describe("mypage mappers", () => {
     });
   });
 
-  it("찜한 모임 응답을 찜 카드 형태로 변환한다", () => {
+  it("찜만 한 모임은 참여 상태 없이 찜 카드 형태로 변환한다", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
 
@@ -370,16 +370,56 @@ describe("mypage mappers", () => {
       location: "성수",
       imageTone: "city",
       actionVariant: "primary",
-      primaryBadge: {
-        label: "참여 중",
-        variant: "scheduled",
-      },
       secondaryBadge: {
         label: "개설확정",
         variant: "confirmed",
         withIcon: true,
       },
     });
+    expect(mapFavoriteMeeting(favorite, 3, 3).primaryBadge).toBeUndefined();
+  });
+
+  it("개설 확정 전 찜만 한 모임은 승인 대기 중 상태를 노출하지 않는다", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
+
+    const favorite: FavoriteWithMeeting = {
+      id: 3,
+      teamId: "dallaem",
+      meetingId: 20,
+      userId: 3,
+      createdAt: "2026-02-01T00:00:00.000Z",
+      meeting: {
+        id: 20,
+        teamId: "dallaem",
+        name: "찜만 한 개설 대기 모임",
+        type: "달램핏",
+        region: "성수",
+        address: null,
+        latitude: null,
+        longitude: null,
+        dateTime: "2026-02-10T14:00:00.000Z",
+        registrationEnd: "2026-02-09T14:00:00.000Z",
+        capacity: 10,
+        participantCount: 5,
+        image: null,
+        description: null,
+        canceledAt: null,
+        confirmedAt: null,
+        hostId: 1,
+        createdBy: 1,
+        createdAt: "2026-02-01T00:00:00.000Z",
+        updatedAt: "2026-02-01T00:00:00.000Z",
+        host: {
+          id: 1,
+          name: "호스트",
+          image: null,
+        },
+      },
+    };
+
+    expect(mapFavoriteMeeting(favorite, 0, 3).primaryBadge).toBeUndefined();
+    expect(mapFavoriteMeeting(favorite, 0, 3).secondaryBadge).toBeUndefined();
   });
 
   it("호스트가 찜한 자신의 모임은 개설 확정 전에도 참여 중으로 표시한다", () => {

--- a/apps/web/src/_pages/mypage/model/mappers.test.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.test.ts
@@ -231,7 +231,7 @@ describe("mypage mappers", () => {
     });
   });
 
-  it("호스트인 참여 모임은 개설 확정 전에도 참여 중으로 표시한다", () => {
+  it("호스트인 참여 모임도 개설 확정 전에는 승인 대기 중으로 표시한다", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
 
@@ -269,8 +269,57 @@ describe("mypage mappers", () => {
     expect(mapJoinedMeeting(meeting, 1, 1)).toMatchObject({
       actionVariant: "secondary",
       primaryBadge: {
-        label: "참여 중",
+        label: "승인 대기 중",
         variant: "waiting",
+      },
+    });
+  });
+
+  it("개설 확정되면 모집 마감 전이라도 참여 중과 초록 버튼으로 표시한다", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
+
+    const meeting: JoinedMeeting = {
+      id: 28,
+      teamId: "dallaem",
+      name: "조기 확정된 모임",
+      type: "스터디",
+      dateTime: "2026-02-10T14:00:00.000Z",
+      region: "강남",
+      address: null,
+      latitude: null,
+      longitude: null,
+      registrationEnd: "2026-02-09T14:00:00.000Z",
+      participantCount: 5,
+      capacity: 10,
+      image: null,
+      description: null,
+      canceledAt: null,
+      confirmedAt: "2026-02-01T10:00:00.000Z",
+      hostId: 1,
+      createdBy: 1,
+      createdAt: "2026-02-01T00:00:00.000Z",
+      updatedAt: "2026-02-01T00:00:00.000Z",
+      host: {
+        id: 1,
+        name: "호스트",
+        image: null,
+      },
+      joinedAt: "2026-02-01T00:00:00.000Z",
+      isReviewed: false,
+      isCompleted: false,
+    };
+
+    expect(mapJoinedMeeting(meeting, 0, 3)).toMatchObject({
+      actionVariant: "primary",
+      primaryBadge: {
+        label: "참여 중",
+        variant: "scheduled",
+      },
+      secondaryBadge: {
+        label: "개설확정",
+        variant: "confirmed",
+        withIcon: true,
       },
     });
   });
@@ -369,7 +418,7 @@ describe("mypage mappers", () => {
       liked: true,
       location: "성수",
       imageTone: "city",
-      actionVariant: "primary",
+      actionVariant: "secondary",
       secondaryBadge: {
         label: "개설확정",
         variant: "confirmed",
@@ -422,7 +471,7 @@ describe("mypage mappers", () => {
     expect(mapFavoriteMeeting(favorite, 0, 3).secondaryBadge).toBeUndefined();
   });
 
-  it("호스트가 찜한 자신의 모임은 개설 확정 전에도 참여 중으로 표시한다", () => {
+  it("호스트가 찜한 자신의 모임도 기본 찜 카드 형태를 유지한다", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
 
@@ -461,12 +510,6 @@ describe("mypage mappers", () => {
       },
     };
 
-    expect(mapFavoriteMeeting(favorite, 0, 1)).toMatchObject({
-      actionVariant: "secondary",
-      primaryBadge: {
-        label: "참여 중",
-        variant: "waiting",
-      },
-    });
+    expect(mapFavoriteMeeting(favorite, 0, 1).primaryBadge).toBeUndefined();
   });
 });

--- a/apps/web/src/_pages/mypage/model/mappers.test.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.test.ts
@@ -75,7 +75,7 @@ describe("mypage mappers", () => {
       location: "강남",
       imageUrl: "https://example.com/meeting.png",
       imageTone: "daylight",
-      actionVariant: "primary",
+      actionVariant: "secondary",
       primaryBadge: {
         label: "참여 예정",
         variant: "scheduled",
@@ -84,6 +84,55 @@ describe("mypage mappers", () => {
         label: "개설대기",
         variant: "waiting",
         withIcon: false,
+      },
+    });
+  });
+
+  it("모집 마감 이후 모임 시작 전이고 개설 확정된 참여 모임은 참여 중 카드로 변환한다", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
+
+    const meeting: JoinedMeeting = {
+      id: 17,
+      teamId: "dallaem",
+      name: "개설 확정된 참여 모임",
+      type: "스터디",
+      dateTime: "2026-02-10T14:00:00.000Z",
+      region: "강남",
+      address: null,
+      latitude: null,
+      longitude: null,
+      registrationEnd: "2026-02-03T14:00:00.000Z",
+      participantCount: 5,
+      capacity: 10,
+      image: null,
+      description: null,
+      canceledAt: null,
+      confirmedAt: "2026-02-03T15:00:00.000Z",
+      hostId: 1,
+      createdBy: 1,
+      createdAt: "2026-02-01T00:00:00.000Z",
+      updatedAt: "2026-02-01T00:00:00.000Z",
+      host: {
+        id: 1,
+        name: "호스트",
+        image: null,
+      },
+      joinedAt: "2026-02-01T00:00:00.000Z",
+      isReviewed: false,
+      isCompleted: false,
+    };
+
+    expect(mapJoinedMeeting(meeting, 1)).toMatchObject({
+      actionVariant: "primary",
+      primaryBadge: {
+        label: "참여 중",
+        variant: "scheduled",
+      },
+      secondaryBadge: {
+        label: "개설확정",
+        variant: "confirmed",
+        withIcon: true,
       },
     });
   });
@@ -230,6 +279,7 @@ describe("mypage mappers", () => {
       liked: true,
       location: "성수",
       imageTone: "city",
+      actionVariant: "secondary",
       secondaryBadge: {
         label: "개설확정",
         variant: "confirmed",

--- a/apps/web/src/_pages/mypage/model/mappers.test.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.test.ts
@@ -20,6 +20,7 @@ describe("mypage mappers", () => {
     };
 
     expect(mapProfile(user)).toEqual({
+      userId: 1,
       name: "홍길동",
       email: "test@example.com",
       imageUrl: "https://example.com/profile.png",
@@ -33,7 +34,7 @@ describe("mypage mappers", () => {
     });
   });
 
-  it("다가오는 참여 모임은 참여 예정 카드로 변환한다", () => {
+  it("개설 확정 전 참여 모임은 승인 대기 중 카드로 변환한다", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
 
@@ -68,7 +69,7 @@ describe("mypage mappers", () => {
       isCompleted: false,
     };
 
-    expect(mapJoinedMeeting(meeting, 1)).toMatchObject({
+    expect(mapJoinedMeeting(meeting, 1, 3)).toMatchObject({
       id: "7",
       title: "달램핏 모임",
       participantCount: "5/10",
@@ -77,18 +78,14 @@ describe("mypage mappers", () => {
       imageTone: "daylight",
       actionVariant: "secondary",
       primaryBadge: {
-        label: "참여 예정",
-        variant: "scheduled",
-      },
-      secondaryBadge: {
-        label: "개설대기",
+        label: "승인 대기 중",
         variant: "waiting",
-        withIcon: false,
       },
     });
+    expect(mapJoinedMeeting(meeting, 1, 3).secondaryBadge).toBeUndefined();
   });
 
-  it("모집 마감 이후 모임 시작 전이고 개설 확정된 참여 모임은 참여 중 카드로 변환한다", () => {
+  it("개설 확정된 참여 모임은 참여 중 카드로 변환한다", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-05T00:00:00.000Z"));
 
@@ -123,7 +120,7 @@ describe("mypage mappers", () => {
       isCompleted: false,
     };
 
-    expect(mapJoinedMeeting(meeting, 1)).toMatchObject({
+    expect(mapJoinedMeeting(meeting, 1, 3)).toMatchObject({
       actionVariant: "primary",
       primaryBadge: {
         label: "참여 중",
@@ -137,7 +134,7 @@ describe("mypage mappers", () => {
     });
   });
 
-  it("지난 참여 모임은 참여 완료 카드로 변환한다", () => {
+  it("개설 확정 전 지난 참여 모임도 승인 대기 중 카드로 변환한다", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-01T00:00:00.000Z"));
 
@@ -172,20 +169,20 @@ describe("mypage mappers", () => {
       isCompleted: true,
     };
 
-    expect(mapJoinedMeeting(meeting, 2)).toMatchObject({
+    expect(mapJoinedMeeting(meeting, 2, 3)).toMatchObject({
       id: "8",
       location: "성수",
       imageTone: "sunset",
       actionVariant: "secondary",
       primaryBadge: {
-        label: "참여 완료",
-        variant: "completed",
+        label: "승인 대기 중",
+        variant: "waiting",
       },
     });
-    expect(mapJoinedMeeting(meeting, 2).secondaryBadge).toBeUndefined();
+    expect(mapJoinedMeeting(meeting, 2, 3).secondaryBadge).toBeUndefined();
   });
 
-  it("개설 확정된 지난 참여 모임은 참여 완료 상태에서도 개설확정 배지를 유지한다", () => {
+  it("개설 확정된 지난 참여 모임도 참여 중 상태와 개설확정 배지를 유지한다", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-01T00:00:00.000Z"));
 
@@ -220,10 +217,61 @@ describe("mypage mappers", () => {
       isCompleted: true,
     };
 
-    expect(mapJoinedMeeting(meeting, 2).secondaryBadge).toMatchObject({
-      label: "개설확정",
-      variant: "confirmed",
-      withIcon: true,
+    expect(mapJoinedMeeting(meeting, 2, 3)).toMatchObject({
+      actionVariant: "primary",
+      primaryBadge: {
+        label: "참여 중",
+        variant: "scheduled",
+      },
+      secondaryBadge: {
+        label: "개설확정",
+        variant: "confirmed",
+        withIcon: true,
+      },
+    });
+  });
+
+  it("호스트인 참여 모임은 개설 확정 전에도 참여 중으로 표시한다", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
+
+    const meeting: JoinedMeeting = {
+      id: 27,
+      teamId: "dallaem",
+      name: "내가 만든 모임이 joined에 보이는 경우",
+      type: "스터디",
+      dateTime: "2026-02-10T14:00:00.000Z",
+      region: "강남",
+      address: null,
+      latitude: null,
+      longitude: null,
+      registrationEnd: null,
+      participantCount: 1,
+      capacity: 10,
+      image: null,
+      description: null,
+      canceledAt: null,
+      confirmedAt: null,
+      hostId: 1,
+      createdBy: 1,
+      createdAt: "2026-02-01T00:00:00.000Z",
+      updatedAt: "2026-02-01T00:00:00.000Z",
+      host: {
+        id: 1,
+        name: "호스트",
+        image: null,
+      },
+      joinedAt: "2026-02-01T00:00:00.000Z",
+      isReviewed: false,
+      isCompleted: false,
+    };
+
+    expect(mapJoinedMeeting(meeting, 1, 1)).toMatchObject({
+      actionVariant: "secondary",
+      primaryBadge: {
+        label: "참여 중",
+        variant: "waiting",
+      },
     });
   });
 
@@ -316,16 +364,68 @@ describe("mypage mappers", () => {
       },
     };
 
-    expect(mapFavoriteMeeting(favorite, 3)).toMatchObject({
+    expect(mapFavoriteMeeting(favorite, 3, 3)).toMatchObject({
       id: "12",
       liked: true,
       location: "성수",
       imageTone: "city",
-      actionVariant: "secondary",
+      actionVariant: "primary",
+      primaryBadge: {
+        label: "참여 중",
+        variant: "scheduled",
+      },
       secondaryBadge: {
         label: "개설확정",
         variant: "confirmed",
         withIcon: true,
+      },
+    });
+  });
+
+  it("호스트가 찜한 자신의 모임은 개설 확정 전에도 참여 중으로 표시한다", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
+
+    const favorite: FavoriteWithMeeting = {
+      id: 2,
+      teamId: "dallaem",
+      meetingId: 19,
+      userId: 1,
+      createdAt: "2026-02-01T00:00:00.000Z",
+      meeting: {
+        id: 19,
+        teamId: "dallaem",
+        name: "내가 만든 찜 모임",
+        type: "달램핏",
+        region: "성수",
+        address: null,
+        latitude: null,
+        longitude: null,
+        dateTime: "2026-02-10T14:00:00.000Z",
+        registrationEnd: "2026-02-09T14:00:00.000Z",
+        capacity: 10,
+        participantCount: 1,
+        image: null,
+        description: null,
+        canceledAt: null,
+        confirmedAt: null,
+        hostId: 1,
+        createdBy: 1,
+        createdAt: "2026-02-01T00:00:00.000Z",
+        updatedAt: "2026-02-01T00:00:00.000Z",
+        host: {
+          id: 1,
+          name: "호스트",
+          image: null,
+        },
+      },
+    };
+
+    expect(mapFavoriteMeeting(favorite, 0, 1)).toMatchObject({
+      actionVariant: "secondary",
+      primaryBadge: {
+        label: "참여 중",
+        variant: "waiting",
       },
     });
   });

--- a/apps/web/src/_pages/mypage/model/mappers.test.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.test.ts
@@ -185,6 +185,48 @@ describe("mypage mappers", () => {
     expect(mapJoinedMeeting(meeting, 2).secondaryBadge).toBeUndefined();
   });
 
+  it("개설 확정된 지난 참여 모임은 참여 완료 상태에서도 개설확정 배지를 유지한다", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-01T00:00:00.000Z"));
+
+    const meeting: JoinedMeeting = {
+      id: 18,
+      teamId: "dallaem",
+      name: "개설 확정 지난 모임",
+      type: "스터디",
+      dateTime: "2026-02-10T14:00:00.000Z",
+      region: "성수",
+      address: null,
+      latitude: null,
+      longitude: null,
+      registrationEnd: "2026-02-03T14:00:00.000Z",
+      participantCount: 8,
+      capacity: 12,
+      image: null,
+      description: null,
+      canceledAt: null,
+      confirmedAt: "2026-02-03T15:00:00.000Z",
+      hostId: 1,
+      createdBy: 1,
+      createdAt: "2026-02-01T00:00:00.000Z",
+      updatedAt: "2026-02-01T00:00:00.000Z",
+      host: {
+        id: 1,
+        name: "호스트",
+        image: null,
+      },
+      joinedAt: "2026-02-01T00:00:00.000Z",
+      isReviewed: false,
+      isCompleted: true,
+    };
+
+    expect(mapJoinedMeeting(meeting, 2).secondaryBadge).toMatchObject({
+      label: "개설확정",
+      variant: "confirmed",
+      withIcon: true,
+    });
+  });
+
   it("내가 만든 모임은 진행 상태에 맞는 카드로 변환한다", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-01T00:00:00.000Z"));

--- a/apps/web/src/_pages/mypage/model/mappers.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.ts
@@ -2,7 +2,6 @@ import type { FavoriteWithMeeting, JoinedMeeting, MeetingWithHost, User } from "
 import type { MoimImageTone, MypageMoimCard, MypageProfile } from "./types";
 
 const imageTones: MoimImageTone[] = ["beige", "daylight", "sunset", "city"];
-type JoinedMeetingStatus = "scheduled" | "active" | "completed";
 
 const getConfirmationBadge = (confirmedAt: string | null | undefined) => {
   return {
@@ -31,44 +30,24 @@ export const formatMeetingDateTime = (dateTime: string | null) => {
   };
 };
 
-const getMeetingTimestamp = (dateTime: string | null) => {
-  if (!dateTime) {
-    return null;
-  }
-
-  const timestamp = new Date(dateTime).getTime();
-
-  return Number.isNaN(timestamp) ? null : timestamp;
-};
-
-const getJoinedMeetingStatus = (registrationEnd: string | null, dateTime: string | null): JoinedMeetingStatus => {
-  const now = Date.now();
-  const registrationEndTime = getMeetingTimestamp(registrationEnd);
-  const meetingTime = getMeetingTimestamp(dateTime);
-
-  if (meetingTime !== null && meetingTime <= now) {
-    return "completed";
-  }
-
-  if (registrationEndTime !== null && registrationEndTime <= now) {
-    return "active";
-  }
-
-  return "scheduled";
-};
-
 export const mapProfile = (user: User): MypageProfile => {
   return {
+    userId: user.id,
     name: user.name,
     email: user.email,
     imageUrl: user.image ?? undefined,
   };
 };
 
-export const mapJoinedMeeting = (meeting: JoinedMeeting, index: number, liked = false): MypageMoimCard => {
+export const mapJoinedMeeting = (
+  meeting: JoinedMeeting,
+  index: number,
+  currentUserId: number,
+  liked = false,
+): MypageMoimCard => {
   const { date, time } = formatMeetingDateTime(meeting.dateTime);
-  const status = getJoinedMeetingStatus(meeting.registrationEnd, meeting.dateTime);
   const isConfirmed = Boolean(meeting.confirmedAt);
+  const isOwnedByCurrentUser = meeting.hostId === currentUserId;
 
   return {
     id: String(meeting.id),
@@ -81,16 +60,12 @@ export const mapJoinedMeeting = (meeting: JoinedMeeting, index: number, liked = 
     liked,
     imageTone: imageTones[index % imageTones.length],
     actionLabel: "스페이스 입장",
-    actionVariant: status === "active" && isConfirmed ? "primary" : "secondary",
+    actionVariant: isConfirmed ? "primary" : "secondary",
     primaryBadge: {
-      label: status === "scheduled" ? "참여 예정" : status === "active" ? "참여 중" : "참여 완료",
-      variant: status === "completed" ? "completed" : "scheduled",
+      label: isConfirmed || isOwnedByCurrentUser ? "참여 중" : "승인 대기 중",
+      variant: isConfirmed ? "scheduled" : "waiting",
     },
-    secondaryBadge: isConfirmed
-      ? getConfirmationBadge(meeting.confirmedAt)
-      : status === "completed"
-        ? undefined
-        : getConfirmationBadge(meeting.confirmedAt),
+    secondaryBadge: isConfirmed ? getConfirmationBadge(meeting.confirmedAt) : undefined,
   };
 };
 
@@ -117,11 +92,15 @@ export const mapCreatedMeeting = (meeting: MeetingWithHost, index: number, liked
   };
 };
 
-export const mapFavoriteMeeting = (favorite: FavoriteWithMeeting, index: number): MypageMoimCard => {
+export const mapFavoriteMeeting = (
+  favorite: FavoriteWithMeeting,
+  index: number,
+  currentUserId: number,
+): MypageMoimCard => {
   const { meeting } = favorite;
   const { date, time } = formatMeetingDateTime(meeting.dateTime);
-  const status = getJoinedMeetingStatus(meeting.registrationEnd, meeting.dateTime);
   const isConfirmed = Boolean(meeting.confirmedAt);
+  const isOwnedByCurrentUser = meeting.hostId === currentUserId;
 
   return {
     id: String(meeting.id),
@@ -134,15 +113,11 @@ export const mapFavoriteMeeting = (favorite: FavoriteWithMeeting, index: number)
     liked: true,
     imageTone: imageTones[index % imageTones.length],
     actionLabel: "스페이스 입장",
-    actionVariant: status === "active" && isConfirmed ? "primary" : "secondary",
+    actionVariant: isConfirmed ? "primary" : "secondary",
     primaryBadge: {
-      label: status === "scheduled" ? "참여 예정" : status === "active" ? "참여 중" : "참여 완료",
-      variant: status === "completed" ? "completed" : "scheduled",
+      label: isConfirmed || isOwnedByCurrentUser ? "참여 중" : "승인 대기 중",
+      variant: isConfirmed ? "scheduled" : "waiting",
     },
-    secondaryBadge: isConfirmed
-      ? getConfirmationBadge(meeting.confirmedAt)
-      : status === "completed"
-        ? undefined
-        : getConfirmationBadge(meeting.confirmedAt),
+    secondaryBadge: isConfirmed ? getConfirmationBadge(meeting.confirmedAt) : undefined,
   };
 };

--- a/apps/web/src/_pages/mypage/model/mappers.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.ts
@@ -1,5 +1,5 @@
 import type { FavoriteWithMeeting, JoinedMeeting, MeetingWithHost, User } from "@moum-zip/api";
-import type { MoimImageTone, MypageMoimCard, MypageProfile } from "./types";
+import type { MoimImageTone, MypageBadge, MypageMoimCard, MypageProfile } from "./types";
 
 const imageTones: MoimImageTone[] = ["beige", "daylight", "sunset", "city"];
 
@@ -101,7 +101,7 @@ export const mapFavoriteMeeting = (
   const { date, time } = formatMeetingDateTime(meeting.dateTime);
   const isConfirmed = Boolean(meeting.confirmedAt);
   const isOwnedByCurrentUser = meeting.hostId === currentUserId;
-  const primaryBadge = isOwnedByCurrentUser
+  const primaryBadge: MypageBadge | undefined = isOwnedByCurrentUser
     ? {
         label: "참여 중",
         variant: isConfirmed ? "scheduled" : "waiting",

--- a/apps/web/src/_pages/mypage/model/mappers.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.ts
@@ -1,5 +1,5 @@
 import type { FavoriteWithMeeting, JoinedMeeting, MeetingWithHost, User } from "@moum-zip/api";
-import type { MoimImageTone, MypageBadge, MypageMoimCard, MypageProfile } from "./types";
+import type { MoimImageTone, MypageMoimCard, MypageProfile } from "./types";
 
 const imageTones: MoimImageTone[] = ["beige", "daylight", "sunset", "city"];
 
@@ -42,12 +42,11 @@ export const mapProfile = (user: User): MypageProfile => {
 export const mapJoinedMeeting = (
   meeting: JoinedMeeting,
   index: number,
-  currentUserId: number,
+  _currentUserId: number,
   liked = false,
 ): MypageMoimCard => {
   const { date, time } = formatMeetingDateTime(meeting.dateTime);
   const isConfirmed = Boolean(meeting.confirmedAt);
-  const isOwnedByCurrentUser = meeting.hostId === currentUserId;
 
   return {
     id: String(meeting.id),
@@ -62,7 +61,7 @@ export const mapJoinedMeeting = (
     actionLabel: "스페이스 입장",
     actionVariant: isConfirmed ? "primary" : "secondary",
     primaryBadge: {
-      label: isConfirmed || isOwnedByCurrentUser ? "참여 중" : "승인 대기 중",
+      label: isConfirmed ? "참여 중" : "승인 대기 중",
       variant: isConfirmed ? "scheduled" : "waiting",
     },
     secondaryBadge: isConfirmed ? getConfirmationBadge(meeting.confirmedAt) : undefined,
@@ -95,18 +94,11 @@ export const mapCreatedMeeting = (meeting: MeetingWithHost, index: number, liked
 export const mapFavoriteMeeting = (
   favorite: FavoriteWithMeeting,
   index: number,
-  currentUserId: number,
+  _currentUserId: number,
 ): MypageMoimCard => {
   const { meeting } = favorite;
   const { date, time } = formatMeetingDateTime(meeting.dateTime);
   const isConfirmed = Boolean(meeting.confirmedAt);
-  const isOwnedByCurrentUser = meeting.hostId === currentUserId;
-  const primaryBadge: MypageBadge | undefined = isOwnedByCurrentUser
-    ? {
-        label: "참여 중",
-        variant: isConfirmed ? "scheduled" : "waiting",
-      }
-    : undefined;
 
   return {
     id: String(meeting.id),
@@ -119,8 +111,8 @@ export const mapFavoriteMeeting = (
     liked: true,
     imageTone: imageTones[index % imageTones.length],
     actionLabel: "스페이스 입장",
-    actionVariant: isConfirmed ? "primary" : "secondary",
-    primaryBadge,
+    actionVariant: "secondary",
+    primaryBadge: undefined,
     secondaryBadge: isConfirmed ? getConfirmationBadge(meeting.confirmedAt) : undefined,
   };
 };

--- a/apps/web/src/_pages/mypage/model/mappers.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.ts
@@ -2,6 +2,7 @@ import type { FavoriteWithMeeting, JoinedMeeting, MeetingWithHost, User } from "
 import type { MoimImageTone, MypageMoimCard, MypageProfile } from "./types";
 
 const imageTones: MoimImageTone[] = ["beige", "daylight", "sunset", "city"];
+type JoinedMeetingStatus = "scheduled" | "active" | "completed";
 
 const getConfirmationBadge = (confirmedAt: string | null | undefined) => {
   return {
@@ -30,6 +31,32 @@ export const formatMeetingDateTime = (dateTime: string | null) => {
   };
 };
 
+const getMeetingTimestamp = (dateTime: string | null) => {
+  if (!dateTime) {
+    return null;
+  }
+
+  const timestamp = new Date(dateTime).getTime();
+
+  return Number.isNaN(timestamp) ? null : timestamp;
+};
+
+const getJoinedMeetingStatus = (registrationEnd: string | null, dateTime: string | null): JoinedMeetingStatus => {
+  const now = Date.now();
+  const registrationEndTime = getMeetingTimestamp(registrationEnd);
+  const meetingTime = getMeetingTimestamp(dateTime);
+
+  if (meetingTime !== null && meetingTime <= now) {
+    return "completed";
+  }
+
+  if (registrationEndTime !== null && registrationEndTime <= now) {
+    return "active";
+  }
+
+  return "scheduled";
+};
+
 export const mapProfile = (user: User): MypageProfile => {
   return {
     name: user.name,
@@ -39,7 +66,9 @@ export const mapProfile = (user: User): MypageProfile => {
 };
 
 export const mapJoinedMeeting = (meeting: JoinedMeeting, index: number, liked = false): MypageMoimCard => {
-  const { date, time, isCompleted } = formatMeetingDateTime(meeting.dateTime);
+  const { date, time } = formatMeetingDateTime(meeting.dateTime);
+  const status = getJoinedMeetingStatus(meeting.registrationEnd, meeting.dateTime);
+  const isConfirmed = Boolean(meeting.confirmedAt);
 
   return {
     id: String(meeting.id),
@@ -52,12 +81,12 @@ export const mapJoinedMeeting = (meeting: JoinedMeeting, index: number, liked = 
     liked,
     imageTone: imageTones[index % imageTones.length],
     actionLabel: "스페이스 입장",
-    actionVariant: isCompleted ? "secondary" : "primary",
+    actionVariant: status === "active" && isConfirmed ? "primary" : "secondary",
     primaryBadge: {
-      label: isCompleted ? "참여 완료" : "참여 예정",
-      variant: isCompleted ? "completed" : "scheduled",
+      label: status === "scheduled" ? "참여 예정" : status === "active" ? "참여 중" : "참여 완료",
+      variant: status === "completed" ? "completed" : "scheduled",
     },
-    secondaryBadge: isCompleted ? undefined : getConfirmationBadge(meeting.confirmedAt),
+    secondaryBadge: status === "completed" ? undefined : getConfirmationBadge(meeting.confirmedAt),
   };
 };
 
@@ -86,7 +115,9 @@ export const mapCreatedMeeting = (meeting: MeetingWithHost, index: number, liked
 
 export const mapFavoriteMeeting = (favorite: FavoriteWithMeeting, index: number): MypageMoimCard => {
   const { meeting } = favorite;
-  const { date, time, isCompleted } = formatMeetingDateTime(meeting.dateTime);
+  const { date, time } = formatMeetingDateTime(meeting.dateTime);
+  const status = getJoinedMeetingStatus(meeting.registrationEnd, meeting.dateTime);
+  const isConfirmed = Boolean(meeting.confirmedAt);
 
   return {
     id: String(meeting.id),
@@ -99,11 +130,11 @@ export const mapFavoriteMeeting = (favorite: FavoriteWithMeeting, index: number)
     liked: true,
     imageTone: imageTones[index % imageTones.length],
     actionLabel: "스페이스 입장",
-    actionVariant: isCompleted ? "secondary" : "primary",
+    actionVariant: status === "active" && isConfirmed ? "primary" : "secondary",
     primaryBadge: {
-      label: isCompleted ? "참여 완료" : "참여 예정",
-      variant: isCompleted ? "completed" : "scheduled",
+      label: status === "scheduled" ? "참여 예정" : status === "active" ? "참여 중" : "참여 완료",
+      variant: status === "completed" ? "completed" : "scheduled",
     },
-    secondaryBadge: isCompleted ? undefined : getConfirmationBadge(meeting.confirmedAt),
+    secondaryBadge: status === "completed" ? undefined : getConfirmationBadge(meeting.confirmedAt),
   };
 };

--- a/apps/web/src/_pages/mypage/model/mappers.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.ts
@@ -86,7 +86,11 @@ export const mapJoinedMeeting = (meeting: JoinedMeeting, index: number, liked = 
       label: status === "scheduled" ? "참여 예정" : status === "active" ? "참여 중" : "참여 완료",
       variant: status === "completed" ? "completed" : "scheduled",
     },
-    secondaryBadge: status === "completed" ? undefined : getConfirmationBadge(meeting.confirmedAt),
+    secondaryBadge: isConfirmed
+      ? getConfirmationBadge(meeting.confirmedAt)
+      : status === "completed"
+        ? undefined
+        : getConfirmationBadge(meeting.confirmedAt),
   };
 };
 
@@ -135,6 +139,10 @@ export const mapFavoriteMeeting = (favorite: FavoriteWithMeeting, index: number)
       label: status === "scheduled" ? "참여 예정" : status === "active" ? "참여 중" : "참여 완료",
       variant: status === "completed" ? "completed" : "scheduled",
     },
-    secondaryBadge: status === "completed" ? undefined : getConfirmationBadge(meeting.confirmedAt),
+    secondaryBadge: isConfirmed
+      ? getConfirmationBadge(meeting.confirmedAt)
+      : status === "completed"
+        ? undefined
+        : getConfirmationBadge(meeting.confirmedAt),
   };
 };

--- a/apps/web/src/_pages/mypage/model/mappers.ts
+++ b/apps/web/src/_pages/mypage/model/mappers.ts
@@ -101,6 +101,12 @@ export const mapFavoriteMeeting = (
   const { date, time } = formatMeetingDateTime(meeting.dateTime);
   const isConfirmed = Boolean(meeting.confirmedAt);
   const isOwnedByCurrentUser = meeting.hostId === currentUserId;
+  const primaryBadge = isOwnedByCurrentUser
+    ? {
+        label: "참여 중",
+        variant: isConfirmed ? "scheduled" : "waiting",
+      }
+    : undefined;
 
   return {
     id: String(meeting.id),
@@ -114,10 +120,7 @@ export const mapFavoriteMeeting = (
     imageTone: imageTones[index % imageTones.length],
     actionLabel: "스페이스 입장",
     actionVariant: isConfirmed ? "primary" : "secondary",
-    primaryBadge: {
-      label: isConfirmed || isOwnedByCurrentUser ? "참여 중" : "승인 대기 중",
-      variant: isConfirmed ? "scheduled" : "waiting",
-    },
+    primaryBadge,
     secondaryBadge: isConfirmed ? getConfirmationBadge(meeting.confirmedAt) : undefined,
   };
 };

--- a/apps/web/src/_pages/mypage/model/types.ts
+++ b/apps/web/src/_pages/mypage/model/types.ts
@@ -5,6 +5,7 @@ export type MoimImageTone = "beige" | "daylight" | "sunset" | "city";
 export type CreatedFilterKey = "ongoing" | "ended";
 
 export interface MypageProfile {
+  userId: number;
   name: string;
   email: string;
   imageUrl?: string;

--- a/apps/web/src/_pages/mypage/model/types.ts
+++ b/apps/web/src/_pages/mypage/model/types.ts
@@ -29,6 +29,6 @@ export interface MypageMoimCard {
   imageTone: MoimImageTone;
   actionLabel: string;
   actionVariant: MypageActionVariant;
-  primaryBadge: MypageBadge;
+  primaryBadge?: MypageBadge;
   secondaryBadge?: MypageBadge;
 }

--- a/apps/web/src/_pages/mypage/queries/get-joined-meetings-query.ts
+++ b/apps/web/src/_pages/mypage/queries/get-joined-meetings-query.ts
@@ -2,7 +2,7 @@
 
 import { fetchMyMeetings, type MypageMoimCard, mapJoinedMeeting } from "../model";
 
-export const getJoinedMeetingsQueryOptions = (initialData: MypageMoimCard[]) => {
+export const getJoinedMeetingsQueryOptions = (initialData: MypageMoimCard[], currentUserId: number) => {
   return {
     queryKey: ["mypage", "meetings", "joined"],
     queryFn: async () => {
@@ -13,7 +13,7 @@ export const getJoinedMeetingsQueryOptions = (initialData: MypageMoimCard[]) => 
         size: 10,
       });
 
-      return response.data.map((meeting, index) => mapJoinedMeeting(meeting, index));
+      return response.data.map((meeting, index) => mapJoinedMeeting(meeting, index, currentUserId));
     },
     initialData,
   } as const;

--- a/apps/web/src/_pages/mypage/queries/get-joined-meetings-query.ts
+++ b/apps/web/src/_pages/mypage/queries/get-joined-meetings-query.ts
@@ -2,9 +2,13 @@
 
 import { fetchMyMeetings, type MypageMoimCard, mapJoinedMeeting } from "../model";
 
+export const getJoinedMeetingsQueryKey = (currentUserId: number) => {
+  return ["mypage", "meetings", "joined", currentUserId] as const;
+};
+
 export const getJoinedMeetingsQueryOptions = (initialData: MypageMoimCard[], currentUserId: number) => {
   return {
-    queryKey: ["mypage", "meetings", "joined"],
+    queryKey: getJoinedMeetingsQueryKey(currentUserId),
     queryFn: async () => {
       const response = await fetchMyMeetings({
         type: "joined",

--- a/apps/web/src/_pages/mypage/queries/index.ts
+++ b/apps/web/src/_pages/mypage/queries/index.ts
@@ -1,2 +1,2 @@
 export { getFavoritesQueryOptions } from "./get-favorites-query";
-export { getJoinedMeetingsQueryOptions } from "./get-joined-meetings-query";
+export { getJoinedMeetingsQueryKey, getJoinedMeetingsQueryOptions } from "./get-joined-meetings-query";

--- a/apps/web/src/_pages/mypage/ui/moim-card.tsx
+++ b/apps/web/src/_pages/mypage/ui/moim-card.tsx
@@ -23,8 +23,7 @@ const imageToneClassName: Record<MoimImageTone, string> = {
 };
 
 const metaLabelClassName = "text-muted-foreground";
-const cardWrapperClassName =
-  "group/card -m-1 w-full rounded-[2rem] p-1 focus-within:rounded-[2rem] focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2";
+const cardWrapperClassName = "group/card -m-1 w-full rounded-[2rem] p-1";
 const cardClassName =
   "relative flex min-h-[24.375rem] w-full flex-col overflow-hidden rounded-3xl bg-card shadow-[0_10px_24px_rgba(17,17,17,0.09)] transition-[transform,box-shadow] duration-300 ease-out motion-reduce:transition-none md:min-h-[14.75rem] md:flex-row md:items-center md:gap-6 md:p-6 md:shadow-[0_10px_24px_rgba(17,17,17,0.09)] md:group-hover/card:-translate-y-0.5 md:group-hover/card:shadow-[0_16px_32px_rgba(17,17,17,0.14)] motion-reduce:md:group-hover/card:translate-y-0 xl:h-[14.75rem] xl:w-[59.875rem]";
 const cardImageClassName =

--- a/apps/web/src/_pages/mypage/ui/moim-card.tsx
+++ b/apps/web/src/_pages/mypage/ui/moim-card.tsx
@@ -110,15 +110,17 @@ export const MoimCard = ({ moim, onToggleLike, onEnterSpace, showActionButton = 
       </div>
 
       <div className="flex min-w-0 flex-1 flex-col gap-5 p-4 md:p-0">
-        <div className="flex flex-wrap items-center gap-2">
-          <Badge variant={moim.primaryBadge.variant}>{moim.primaryBadge.label}</Badge>
-          {moim.secondaryBadge ? (
-            <Badge variant={moim.secondaryBadge.variant}>
-              {moim.secondaryBadge.withIcon ? <CheckCircleIcon /> : null}
-              {moim.secondaryBadge.label}
-            </Badge>
-          ) : null}
-        </div>
+        {moim.primaryBadge || moim.secondaryBadge ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {moim.primaryBadge ? <Badge variant={moim.primaryBadge.variant}>{moim.primaryBadge.label}</Badge> : null}
+            {moim.secondaryBadge ? (
+              <Badge variant={moim.secondaryBadge.variant}>
+                {moim.secondaryBadge.withIcon ? <CheckCircleIcon /> : null}
+                {moim.secondaryBadge.label}
+              </Badge>
+            ) : null}
+          </div>
+        ) : null}
 
         <div className="space-y-5">
           <h3 className="font-bold text-2xl text-foreground leading-tight">{moim.title}</h3>

--- a/apps/web/src/_pages/mypage/ui/mypage-view.tsx
+++ b/apps/web/src/_pages/mypage/ui/mypage-view.tsx
@@ -53,6 +53,7 @@ export function MypageView({
     moims,
     createdMoims,
     enableRemoteFetch,
+    profile,
   });
 
   return (

--- a/apps/web/src/_pages/mypage/use-cases/favorite-state.ts
+++ b/apps/web/src/_pages/mypage/use-cases/favorite-state.ts
@@ -19,6 +19,7 @@ export const buildLikedMeetings = (
   favoriteList: FavoriteList | undefined,
   fallbackMoims: MypageMoimCard[],
   enableRemoteFetch: boolean,
+  currentUserId: number,
 ) => {
   if (!enableRemoteFetch) {
     return fallbackMoims;
@@ -28,7 +29,7 @@ export const buildLikedMeetings = (
     return fallbackMoims;
   }
 
-  return favoriteList.data.map(mapFavoriteMeeting);
+  return favoriteList.data.map((favorite, index) => mapFavoriteMeeting(favorite, index, currentUserId));
 };
 
 export const updateLikedState = (moims: MypageMoimCard[] | undefined, meetingId: string, nextLiked: boolean) => {

--- a/apps/web/src/_pages/mypage/use-cases/favorite-state.ts
+++ b/apps/web/src/_pages/mypage/use-cases/favorite-state.ts
@@ -32,6 +32,26 @@ export const buildLikedMeetings = (
   return favoriteList.data.map((favorite, index) => mapFavoriteMeeting(favorite, index, currentUserId));
 };
 
+export const mergeEnterableLikedMeetings = (
+  likedMeetings: MypageMoimCard[],
+  enterableMeetings: MypageMoimCard[],
+): MypageMoimCard[] => {
+  const enterableMeetingMap = new Map(enterableMeetings.map((meeting) => [meeting.id, meeting]));
+
+  return likedMeetings.map((meeting) => {
+    const enterableMeeting = enterableMeetingMap.get(meeting.id);
+
+    if (!enterableMeeting) {
+      return meeting;
+    }
+
+    return {
+      ...enterableMeeting,
+      liked: true,
+    };
+  });
+};
+
 export const updateLikedState = (moims: MypageMoimCard[] | undefined, meetingId: string, nextLiked: boolean) => {
   if (!moims) {
     return moims;

--- a/apps/web/src/_pages/mypage/use-cases/get-mypage-page-data.ts
+++ b/apps/web/src/_pages/mypage/use-cases/get-mypage-page-data.ts
@@ -52,9 +52,9 @@ export const getMypagePageData = async ({
     profile,
     moims: {
       joined: joinedMeetings.data.map((meeting, index) =>
-        mapJoinedMeeting(meeting, index, favoriteMeetingIds.has(meeting.id)),
+        mapJoinedMeeting(meeting, index, user.id, favoriteMeetingIds.has(meeting.id)),
       ),
-      liked: favoritesList.data.map(mapFavoriteMeeting),
+      liked: favoritesList.data.map((favorite, index) => mapFavoriteMeeting(favorite, index, user.id)),
     },
     createdMoims: {
       ongoing: [],

--- a/apps/web/src/_pages/mypage/use-cases/index.ts
+++ b/apps/web/src/_pages/mypage/use-cases/index.ts
@@ -1,4 +1,10 @@
-export { applyFavoriteState, buildFavoriteMeetingIds, buildLikedMeetings, updateLikedState } from "./favorite-state";
+export {
+  applyFavoriteState,
+  buildFavoriteMeetingIds,
+  buildLikedMeetings,
+  mergeEnterableLikedMeetings,
+  updateLikedState,
+} from "./favorite-state";
 export { getCreatedMeetingCards } from "./get-created-meeting-cards";
 export { getMypagePageData } from "./get-mypage-page-data";
 export { useToggleFavorite } from "./toggle-favorite";

--- a/apps/web/src/_pages/mypage/use-cases/toggle-favorite.ts
+++ b/apps/web/src/_pages/mypage/use-cases/toggle-favorite.ts
@@ -5,11 +5,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRef } from "react";
 import { createFavorite, deleteFavorite } from "../model";
 import type { MypageMoimCard } from "../model/types";
+import { getJoinedMeetingsQueryKey } from "../queries";
 import { updateLikedState } from "./favorite-state";
 
 interface ToggleFavoriteMutationParams {
   meetingId: number;
   nextLiked: boolean;
+  currentUserId: number;
 }
 
 interface CreatedMeetingsCache {
@@ -122,11 +124,12 @@ export const useToggleFavorite = (enableRemoteFetch: boolean) => {
       await deleteFavorite(meetingId);
       return null;
     },
-    onMutate: async ({ meetingId, nextLiked }) => {
+    onMutate: async ({ meetingId, nextLiked, currentUserId }) => {
       // meetingId별 최신 요청 버전을 기록해 늦게 도착한 이전 응답을 무시합니다.
       const requestVersion = (requestVersionRef.current.get(meetingId) ?? 0) + 1;
       requestVersionRef.current.set(meetingId, requestVersion);
       const meetingIdString = String(meetingId);
+      const joinedQueryKey = getJoinedMeetingsQueryKey(currentUserId);
 
       // 진행 중인 refetch 응답이 optimistic state를 덮어쓰지 않도록 먼저 취소합니다.
       await Promise.all([
@@ -135,14 +138,14 @@ export const useToggleFavorite = (enableRemoteFetch: boolean) => {
         queryClient.cancelQueries({ queryKey: ["mypage", "favorites"] }),
       ]);
 
-      const previousJoined = queryClient.getQueryData<MypageMoimCard[]>(["mypage", "meetings", "joined"]);
+      const previousJoined = queryClient.getQueryData<MypageMoimCard[]>(joinedQueryKey);
       const previousCreated = queryClient.getQueryData<CreatedMeetingsCache>(["mypage", "meetings", "created"]);
       const previousFavorites = queryClient.getQueryData<FavoriteList>(["mypage", "favorites"]);
       const previousFavoriteIndex =
         previousFavorites?.data.findIndex((favorite) => favorite.meetingId === meetingId) ?? -1;
       const previousFavorite = previousFavoriteIndex >= 0 ? previousFavorites?.data[previousFavoriteIndex] : undefined;
 
-      queryClient.setQueryData<MypageMoimCard[]>(["mypage", "meetings", "joined"], (current) =>
+      queryClient.setQueryData<MypageMoimCard[]>(joinedQueryKey, (current) =>
         updateLikedState(current, meetingIdString, nextLiked),
       );
       queryClient.setQueryData<CreatedMeetingsCache>(["mypage", "meetings", "created"], (current) =>
@@ -204,8 +207,9 @@ export const useToggleFavorite = (enableRemoteFetch: boolean) => {
       }
 
       const meetingIdString = String(variables.meetingId);
+      const joinedQueryKey = getJoinedMeetingsQueryKey(variables.currentUserId);
 
-      queryClient.setQueryData<MypageMoimCard[]>(["mypage", "meetings", "joined"], (current) =>
+      queryClient.setQueryData<MypageMoimCard[]>(joinedQueryKey, (current) =>
         restoreLikedState(current, meetingIdString, context.previousJoinedLiked),
       );
       queryClient.setQueryData<CreatedMeetingsCache>(["mypage", "meetings", "created"], (current) =>


### PR DESCRIPTION
## 📌 Summary

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- close #201 
- 마이페이지 모임 카드의 참여 상태 및 스페이스 입장 버튼 색상 기준을 수정했습니다.
- 나의 모임과 찜한 모임에서 참여 상태를 시간 기준에 따라 참여 예정 / 참여 중 / 참여 완료로 다시 계산하고, 참여 중 + 개설확정인 경우에만 스페이스 입장 버튼이 초록색으로 노출되도록 반영했습니다.

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- 마이페이지 나의 모임 / 찜한 모임의 참여 상태 계산 기준 수정
- registrationEnd, dateTime 기준으로 참여 예정 / 참여 중 / 참여 완료 상태 분기 적용
- 참여 중이면서 confirmedAt이 있는 경우에만 스페이스 입장 버튼이 초록색으로 노출되도록 수정

## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

- 참여 중 상태를 registrationEnd <= now < dateTime으로 해석한 현재 정책이 기획 의도와 맞는지 확인 부탁드립니다.

## 📸 Screenshot

_작업한 내용에 대한 스크린샷을 첨부해주세요._

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - 마이페이지가 현재 사용자 식별을 반영해 즐겨찾기·참여 상태를 사용자별로 정확히 구분해 표시

* **Bug Fixes**
  - 모임 카드의 버튼 스타일·주·보조 배지 표시가 개설 확정 여부와 소유권에 따라 일관되게 반영되도록 개선
  - 확정 전/확정 후, 호스트 여부에 따른 배지 문구·우선순위 정비

* **Tests**
  - 날짜 의존 시나리오 보강 및 고정 시간으로 매핑 동작 검증 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->