### PR TITLE
[feat] 마이페이지 모임 카드 상세 이동 및 추천 모임 중복 방어

### DIFF
--- a/apps/web/src/_pages/mypage/ui/moim-card.tsx
+++ b/apps/web/src/_pages/mypage/ui/moim-card.tsx
@@ -4,6 +4,8 @@ import { Badge, Button, CheckCircleIcon, UtilityButton } from "@ui/components";
 import { Heart } from "@ui/icons";
 import { cn } from "@ui/lib/utils";
 import Image from "next/image";
+import Link from "next/link";
+import { ROUTES } from "@/shared/config/routes";
 import type { MoimImageTone, MypageMoimCard } from "../model/types";
 
 interface MoimCardProps {
@@ -21,6 +23,13 @@ const imageToneClassName: Record<MoimImageTone, string> = {
 };
 
 const metaLabelClassName = "text-muted-foreground";
+const cardWrapperClassName = "group/card -m-1 w-full rounded-[2rem] p-1";
+const cardClassName =
+  "relative flex min-h-[24.375rem] w-full flex-col overflow-hidden rounded-3xl bg-card shadow-[0_10px_24px_rgba(17,17,17,0.09)] transition-[transform,box-shadow] duration-300 ease-out motion-reduce:transition-none md:min-h-[14.75rem] md:flex-row md:items-center md:gap-6 md:p-6 md:shadow-[0_10px_24px_rgba(17,17,17,0.09)] lg:group-hover/card:-translate-y-0.5 lg:group-hover/card:shadow-[0_16px_32px_rgba(17,17,17,0.14)] motion-reduce:lg:group-hover/card:translate-y-0 xl:h-[14.75rem] xl:w-[59.875rem]";
+const cardImageClassName =
+  "aspect-[343/156] rounded-t-3xl transition-transform duration-300 ease-out motion-reduce:transition-none md:aspect-square md:size-[11.75rem] md:rounded-3xl lg:group-hover/card:scale-[1.015] motion-reduce:lg:group-hover/card:scale-100";
+const cardTitleClassName =
+  "font-bold text-2xl text-foreground leading-tight transition-colors duration-300 motion-reduce:transition-none lg:group-hover/card:text-primary";
 
 interface HeartButtonProps {
   isLiked: boolean;
@@ -79,6 +88,7 @@ const MoimPreview = ({ imageTone, imageUrl, className }: MoimPreviewProps) => {
 
 export const MoimCard = ({ moim, onToggleLike, onEnterSpace, showActionButton = true }: MoimCardProps) => {
   const actionVariant = moim.actionVariant === "primary" ? "primary" : "secondary";
+  const detailHref = `${ROUTES.moimDetail}/${moim.id}`;
 
   const handleToggleLike = () => {
     onToggleLike?.(moim.id);
@@ -89,7 +99,7 @@ export const MoimCard = ({ moim, onToggleLike, onEnterSpace, showActionButton = 
       type="button"
       variant={actionVariant}
       size="small"
-      className={className}
+      className={cn("relative z-20", className)}
       onClick={() => onEnterSpace?.(moim.id)}
     >
       {moim.actionLabel}
@@ -97,58 +107,63 @@ export const MoimCard = ({ moim, onToggleLike, onEnterSpace, showActionButton = 
   );
 
   return (
-    <article className="flex min-h-[24.375rem] w-full flex-col overflow-hidden rounded-3xl bg-card shadow-sm md:min-h-[14.75rem] md:flex-row md:items-center md:gap-6 md:p-6 md:shadow-sm xl:h-[14.75rem] xl:w-[59.875rem]">
-      <div className="relative w-full md:w-[11.75rem] md:min-w-[11.75rem]">
-        <MoimPreview
-          imageTone={moim.imageTone}
-          imageUrl={moim.imageUrl}
-          className="aspect-[343/156] rounded-t-3xl md:aspect-square md:size-[11.75rem] md:rounded-3xl"
+    <div className={cardWrapperClassName}>
+      <article className={cardClassName}>
+        <Link
+          aria-label={`${moim.title} 상세 페이지 보기`}
+          className="absolute inset-0 z-10 rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          href={detailHref}
+          prefetch={false}
         />
-        <div className="absolute top-4 right-4 md:hidden">
-          <HeartButton isLiked={moim.liked} onToggle={handleToggleLike} className="bg-white shadow-sm" />
-        </div>
-      </div>
 
-      <div className="flex min-w-0 flex-1 flex-col gap-5 p-4 md:p-0">
-        <div className="flex flex-wrap items-center gap-2">
-          <Badge variant={moim.primaryBadge.variant}>{moim.primaryBadge.label}</Badge>
-          {moim.secondaryBadge ? (
-            <Badge variant={moim.secondaryBadge.variant}>
-              {moim.secondaryBadge.withIcon ? <CheckCircleIcon /> : null}
-              {moim.secondaryBadge.label}
-            </Badge>
-          ) : null}
-        </div>
-
-        <div className="space-y-5">
-          <h3 className="font-bold text-2xl text-foreground leading-tight">{moim.title}</h3>
-
-          <div className="space-y-2 text-base text-muted-foreground">
-            <div className="flex items-center gap-2 font-medium text-foreground">
-              <svg viewBox="0 0 20 20" className="size-4 fill-current text-muted-foreground" aria-hidden="true">
-                <path d="M10 10a3.75 3.75 0 1 0 0-7.5A3.75 3.75 0 0 0 10 10Zm0 1.875c-3.127 0-5.625 1.655-5.625 3.75A.625.625 0 0 0 5 16.25h10a.625.625 0 0 0 .625-.625c0-2.095-2.498-3.75-5.625-3.75Z" />
-              </svg>
-              <span>{moim.participantCount}</span>
-            </div>
-
-            <p className="leading-relaxed">
-              {moim.location}
-              <span className="mx-2 text-border">|</span>
-              <span className={metaLabelClassName}>날짜</span> {moim.date}
-              <span className="mx-2 text-border">|</span>
-              <span className={metaLabelClassName}>시간</span> {moim.time}
-            </p>
+        <div className="relative w-full md:w-[11.75rem] md:min-w-[11.75rem]">
+          <MoimPreview imageTone={moim.imageTone} imageUrl={moim.imageUrl} className={cardImageClassName} />
+          <div className="absolute top-4 right-4 z-20 md:hidden">
+            <HeartButton isLiked={moim.liked} onToggle={handleToggleLike} className="bg-white shadow-sm" />
           </div>
         </div>
 
-        {showActionButton ? renderActionButton("mt-auto h-12 min-w-[9.75rem] self-end text-base md:hidden") : null}
-      </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-5 p-4 md:p-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={moim.primaryBadge.variant}>{moim.primaryBadge.label}</Badge>
+            {moim.secondaryBadge ? (
+              <Badge variant={moim.secondaryBadge.variant}>
+                {moim.secondaryBadge.withIcon ? <CheckCircleIcon /> : null}
+                {moim.secondaryBadge.label}
+              </Badge>
+            ) : null}
+          </div>
 
-      <div className="hidden items-center justify-between gap-4 md:ml-auto md:flex md:w-[11rem] md:flex-col md:items-end md:self-stretch">
-        <HeartButton isLiked={moim.liked} onToggle={handleToggleLike} className="bg-card" />
+          <div className="space-y-5">
+            <h3 className={cardTitleClassName}>{moim.title}</h3>
 
-        {showActionButton ? renderActionButton("h-12 min-w-[9.75rem] text-base") : null}
-      </div>
-    </article>
+            <div className="space-y-2 text-base text-muted-foreground">
+              <div className="flex items-center gap-2 font-medium text-foreground">
+                <svg viewBox="0 0 20 20" className="size-4 fill-current text-muted-foreground" aria-hidden="true">
+                  <path d="M10 10a3.75 3.75 0 1 0 0-7.5A3.75 3.75 0 0 0 10 10Zm0 1.875c-3.127 0-5.625 1.655-5.625 3.75A.625.625 0 0 0 5 16.25h10a.625.625 0 0 0 .625-.625c0-2.095-2.498-3.75-5.625-3.75Z" />
+                </svg>
+                <span>{moim.participantCount}</span>
+              </div>
+
+              <p className="leading-relaxed">
+                {moim.location}
+                <span className="mx-2 text-border">|</span>
+                <span className={metaLabelClassName}>날짜</span> {moim.date}
+                <span className="mx-2 text-border">|</span>
+                <span className={metaLabelClassName}>시간</span> {moim.time}
+              </p>
+            </div>
+          </div>
+
+          {showActionButton ? renderActionButton("mt-auto h-12 min-w-[9.75rem] self-end text-base md:hidden") : null}
+        </div>
+
+        <div className="hidden items-center justify-between gap-4 md:ml-auto md:flex md:w-[11rem] md:flex-col md:items-end md:self-stretch">
+          <HeartButton isLiked={moim.liked} onToggle={handleToggleLike} className="relative z-20 bg-card" />
+
+          {showActionButton ? renderActionButton("h-12 min-w-[9.75rem] text-base") : null}
+        </div>
+      </article>
+    </div>
   );
 };

--- a/apps/web/src/_pages/mypage/ui/moim-card.tsx
+++ b/apps/web/src/_pages/mypage/ui/moim-card.tsx
@@ -23,7 +23,8 @@ const imageToneClassName: Record<MoimImageTone, string> = {
 };
 
 const metaLabelClassName = "text-muted-foreground";
-const cardWrapperClassName = "group/card -m-1 w-full rounded-[2rem] p-1";
+const cardWrapperClassName =
+  "group/card -m-1 w-full rounded-[2rem] p-1 focus-within:rounded-[2rem] focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2";
 const cardClassName =
   "relative flex min-h-[24.375rem] w-full flex-col overflow-hidden rounded-3xl bg-card shadow-[0_10px_24px_rgba(17,17,17,0.09)] transition-[transform,box-shadow] duration-300 ease-out motion-reduce:transition-none md:min-h-[14.75rem] md:flex-row md:items-center md:gap-6 md:p-6 md:shadow-[0_10px_24px_rgba(17,17,17,0.09)] md:group-hover/card:-translate-y-0.5 md:group-hover/card:shadow-[0_16px_32px_rgba(17,17,17,0.14)] motion-reduce:md:group-hover/card:translate-y-0 xl:h-[14.75rem] xl:w-[59.875rem]";
 const cardImageClassName =
@@ -111,7 +112,7 @@ export const MoimCard = ({ moim, onToggleLike, onEnterSpace, showActionButton = 
       <article className={cardClassName}>
         <Link
           aria-label={`${moim.title} 상세 페이지 보기`}
-          className="absolute inset-0 z-10 rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="absolute inset-0 z-10 rounded-3xl focus-visible:outline-none"
           href={detailHref}
           prefetch={false}
         />

--- a/apps/web/src/_pages/mypage/ui/moim-card.tsx
+++ b/apps/web/src/_pages/mypage/ui/moim-card.tsx
@@ -25,11 +25,11 @@ const imageToneClassName: Record<MoimImageTone, string> = {
 const metaLabelClassName = "text-muted-foreground";
 const cardWrapperClassName = "group/card -m-1 w-full rounded-[2rem] p-1";
 const cardClassName =
-  "relative flex min-h-[24.375rem] w-full flex-col overflow-hidden rounded-3xl bg-card shadow-[0_10px_24px_rgba(17,17,17,0.09)] transition-[transform,box-shadow] duration-300 ease-out motion-reduce:transition-none md:min-h-[14.75rem] md:flex-row md:items-center md:gap-6 md:p-6 md:shadow-[0_10px_24px_rgba(17,17,17,0.09)] lg:group-hover/card:-translate-y-0.5 lg:group-hover/card:shadow-[0_16px_32px_rgba(17,17,17,0.14)] motion-reduce:lg:group-hover/card:translate-y-0 xl:h-[14.75rem] xl:w-[59.875rem]";
+  "relative flex min-h-[24.375rem] w-full flex-col overflow-hidden rounded-3xl bg-card shadow-[0_10px_24px_rgba(17,17,17,0.09)] transition-[transform,box-shadow] duration-300 ease-out motion-reduce:transition-none md:min-h-[14.75rem] md:flex-row md:items-center md:gap-6 md:p-6 md:shadow-[0_10px_24px_rgba(17,17,17,0.09)] md:group-hover/card:-translate-y-0.5 md:group-hover/card:shadow-[0_16px_32px_rgba(17,17,17,0.14)] motion-reduce:md:group-hover/card:translate-y-0 xl:h-[14.75rem] xl:w-[59.875rem]";
 const cardImageClassName =
-  "aspect-[343/156] rounded-t-3xl transition-transform duration-300 ease-out motion-reduce:transition-none md:aspect-square md:size-[11.75rem] md:rounded-3xl lg:group-hover/card:scale-[1.015] motion-reduce:lg:group-hover/card:scale-100";
+  "aspect-[343/156] rounded-t-3xl transition-transform duration-300 ease-out motion-reduce:transition-none md:aspect-square md:size-[11.75rem] md:rounded-3xl md:group-hover/card:scale-[1.015] motion-reduce:md:group-hover/card:scale-100";
 const cardTitleClassName =
-  "font-bold text-2xl text-foreground leading-tight transition-colors duration-300 motion-reduce:transition-none lg:group-hover/card:text-primary";
+  "font-bold text-2xl text-foreground leading-tight transition-colors duration-300 motion-reduce:transition-none md:group-hover/card:text-primary";
 
 interface HeartButtonProps {
   isLiked: boolean;

--- a/apps/web/src/entities/moim-detail/model/sort-recommended-meetings.ts
+++ b/apps/web/src/entities/moim-detail/model/sort-recommended-meetings.ts
@@ -96,7 +96,7 @@ export const sortRecommendedMeetings = <T extends RecommendedMeetingBase>(
   meetings: T[],
   currentMeeting: CurrentMeetingBase,
 ) => {
-  return [...meetings]
+  const sortedMeetings = [...meetings]
     .filter((meeting) => meeting.id !== currentMeeting.id)
     .sort((a, b) => {
       const aPriority = getMatchPriority(a, currentMeeting);
@@ -121,6 +121,18 @@ export const sortRecommendedMeetings = <T extends RecommendedMeetingBase>(
       }
 
       return (b.participantCount ?? 0) - (a.participantCount ?? 0);
-    })
-    .slice(0, RECOMMEND_LIMIT);
+    });
+
+  const uniqueMeetings = sortedMeetings.reduce<T[]>((accumulator, meeting) => {
+    const isDuplicatedMeeting = accumulator.some((candidate) => candidate.id === meeting.id);
+
+    if (isDuplicatedMeeting) {
+      return accumulator;
+    }
+
+    accumulator.push(meeting);
+    return accumulator;
+  }, []);
+
+  return uniqueMeetings.slice(0, RECOMMEND_LIMIT);
 };


### PR DESCRIPTION
## 📌 Summary

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- close #205 
- 마이페이지 모임 카드에 모임찾기와 동일한 상세 이동 UX를 적용했습니다.
카드 전체 클릭 시 모임 상세 페이지로 이동하도록 변경했고, hover 인터랙션도 모임찾기 카드와 유사한 방식으로 맞췄습니다.

- 추가로, 모임 상세 페이지의 추천 모임 리스트에서 동일한 `meetingId`가 중복 포함될 때 React `key` 경고가 발생하는 문제를 방어했습니다.
추천 모임 정렬 단계에서 `meetingId` 기준 dedupe를 적용해 중복 카드가 렌더링되지 않도록 수정했습니다.

## 📄 Tasks

_해당 PR에 수행한 작업을 작성해주세요._

- 마이페이지 모임 카드 전체 클릭 시 모임 상세 페이지로 이동하도록 링크 구조 적용
- 마이페이지 모임 카드에 모임찾기와 유사한 hover 인터랙션 적용
- 카드 내부 찜 버튼과 기존 액션 버튼은 기존 동작이 유지되도록 z-index 분리
- 모임 상세 추천 모임 정렬 단계에서 `meetingId` 기준 dedupe 적용
- 추천 모임 중복으로 인한 React `key` 경고 방어

## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

중복 카드 렌더링 문제

원인
- 모임 상세 추천 목록 오류는 추천 모임 데이터 생성 과정에서 발생했습니다.

확인 결과
- `/meetings` cursor pagination 응답이 페이지 간 일부 동일한 모임 데이터를 중복 포함하고 있었습니다.
- 그 데이터가 추천 모임 후보에 누적되면서 동일한 `meetingId`가 여러 번 포함될 수 있었습니다.
- 특정 모임에서는 중복 데이터가 최종 추천 상위 4개 안에 들어오면서 React `key` 경고가 발생했습니다.
## 📸 Screenshot

_작업한 내용에 대한 스크린샷을 첨부해주세요._

-
![Apr-10-2026 18-13-10](https://github.com/user-attachments/assets/de418584-88a9-47fd-b605-c70f39d6e346)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모임 카드 전체를 클릭해 상세 페이지로 바로 이동 가능

* **개선사항**
  * 카드 레이아웃과 호버 효과 개선으로 시각적 반응 향상
  * 액션 버튼 및 즐겨찾기 버튼의 우선순위 조정으로 클릭 가능성 개선

* **버그 수정 / 품질 개선**
  * 추천 모임 목록에서 중복 항목을 제거해 추천 정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->