### PR TITLE
[feat] 모임 상세 페이지 UX 개선

### DIFF
--- a/apps/web/src/_pages/moim-detail/ui/description-section.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/description-section.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { cn } from "@ui/lib/utils";
+import Image from "next/image";
 
 interface DescriptionSectionProps {
   title?: string;
   description?: string;
   className?: string;
   contentClassName?: string;
+  hostName?: string;
+  hostImage?: string | null;
 }
 
 export const DescriptionSection = ({
@@ -14,23 +17,39 @@ export const DescriptionSection = ({
   description = "",
   className,
   contentClassName,
+  hostName,
+  hostImage,
 }: DescriptionSectionProps) => {
+  const initial = hostName?.trim().charAt(0) ?? "";
+
   return (
     <section className={cn("flex flex-col gap-4", className)}>
       <h2 className="font-semibold text-black text-xl leading-[1.4]">{title}</h2>
 
-      <div
-        className={cn(
-          "rounded-[1rem] bg-white px-6 py-5 font-normal text-base text-gray-700 leading-[1.6]",
-          "md:px-8 md:text-[17px]",
-          contentClassName,
-        )}
-      >
+      <div className={cn("rounded-[1rem] bg-white px-6 py-5 md:px-8", contentClassName)}>
         {description ? (
-          <p className="whitespace-pre-line break-words">{description}</p>
+          <p className="whitespace-pre-line break-words font-normal text-base text-gray-700 leading-[1.7] md:text-[17px]">
+            {description}
+          </p>
         ) : (
-          <p className="text-gray-400">설명이 없습니다.</p>
+          <p className="font-normal text-base text-gray-400 leading-[1.6] md:text-[17px]">설명이 없습니다.</p>
         )}
+
+        {hostName ? (
+          <div className="mt-6 flex items-center gap-2.5">
+            <div className="relative flex h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full bg-slate-100">
+              {hostImage ? (
+                <Image src={hostImage} alt={`${hostName} 프로필 이미지`} fill className="object-cover" />
+              ) : (
+                <span className="font-medium text-[12px] text-slate-500">{initial}</span>
+              )}
+            </div>
+
+            <span className="text-[13px] text-slate-400 leading-[1.4]">매니저</span>
+
+            <span className="truncate font-medium text-[14px] text-slate-700 leading-[1.5]">{hostName}</span>
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/apps/web/src/_pages/moim-detail/ui/information-container.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/information-container.tsx
@@ -36,7 +36,9 @@ interface ActionButtonProps {
 
 const ActionButton = ({ label, onClick, variant = "primary", disabled = false }: ActionButtonProps) => {
   const secondaryClassName =
-    variant === "secondary" ? "border border-primary bg-white text-green-600 hover:bg-green-50" : "";
+    variant === "secondary"
+      ? "border border-primary bg-white text-green-600 hover:bg-green-50 hover:text-green-700"
+      : "";
 
   const successClassName =
     variant === "success"

--- a/apps/web/src/_pages/moim-detail/ui/information-container.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/information-container.tsx
@@ -102,6 +102,7 @@ export const InformationContainer = ({
   onLoginAction,
 }: InformationContainerProps) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isCancelJoinModalOpen, setIsCancelJoinModalOpen] = useState(false);
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
   const isManager = viewType === "manager";
@@ -163,7 +164,7 @@ export const InformationContainer = ({
     return await onToggleLike();
   };
 
-  const handleMainButtonClick = () => {
+  const handleJoinClick = () => {
     if (isManager) {
       return;
     }
@@ -173,14 +174,25 @@ export const InformationContainer = ({
       return;
     }
 
-    if (canJoin) {
-      onParticipateToggle?.(data.id, true);
+    onParticipateToggle?.(data.id, true);
+  };
+
+  const handleCancelJoinClick = () => {
+    if (isManager) {
       return;
     }
 
-    if (canCancelJoin) {
-      onParticipateToggle?.(data.id, false);
+    if (!isLoggedIn) {
+      setIsLoginModalOpen(true);
+      return;
     }
+
+    setIsCancelJoinModalOpen(true);
+  };
+
+  const handleCancelJoinConfirm = () => {
+    onParticipateToggle?.(data.id, false);
+    setIsCancelJoinModalOpen(false);
   };
 
   const handleDeleteConfirm = () => {
@@ -202,13 +214,13 @@ export const InformationContainer = ({
     : canCancelJoin
       ? {
           label: "신청 취소하기",
-          onClick: handleMainButtonClick,
+          onClick: handleCancelJoinClick,
           variant: "secondary",
         }
       : canJoin
         ? {
             label: "신청하기",
-            onClick: handleMainButtonClick,
+            onClick: handleJoinClick,
             variant: "primary",
           }
         : isParticipating
@@ -311,6 +323,16 @@ export const InformationContainer = ({
           cancelText="취소"
           actionText="확인"
           onAction={handleDeleteConfirm}
+        />
+      </AlertModal>
+
+      <AlertModal open={isCancelJoinModalOpen} onOpenChange={setIsCancelJoinModalOpen}>
+        <AlertModal.Content
+          title="모임 신청을 취소하시겠어요?"
+          description="신청 취소 후 다시 신청해야 참여할 수 있습니다."
+          cancelText="닫기"
+          actionText="신청 취소하기"
+          onAction={handleCancelJoinConfirm}
         />
       </AlertModal>
 

--- a/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
@@ -304,7 +304,11 @@ export const MoimDetailClient = ({
             </div>
           </section>
 
-          <DescriptionSection description={initialDescription} />
+          <DescriptionSection
+            description={initialDescription}
+            hostName={state.informationData.hostName}
+            hostImage={state.informationData.hostImage}
+          />
 
           <section className="flex flex-col gap-4">
             <h2 className="font-semibold text-black text-xl leading-[1.4]">이런 모임은 어때요?</h2>

--- a/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ChevronLeft } from "@moum-zip/ui/icons";
 import { toast } from "@ui/components";
 import Image from "next/image";
 import Link from "next/link";
@@ -254,88 +255,108 @@ export const MoimDetailClient = ({
 
   return (
     <div className="min-h-screen">
-      <main className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 pt-6 pb-20 sm:px-6 lg:pt-8">
-        <section className="grid grid-cols-1 gap-4 md:grid-cols-[0.95fr_1.05fr] md:items-stretch">
-          <div className="relative aspect-[630/400] h-full w-full overflow-hidden rounded-[16px] md:rounded-[20px]">
-            {state.informationData.image ? (
-              <Image src={state.informationData.image} alt="모임 대표 이미지" fill className="object-cover" />
-            ) : (
-              <div className="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400 text-sm">
-                이미지 영역
-              </div>
-            )}
-          </div>
+      <main className="mx-auto flex w-full max-w-6xl flex-col px-4 pb-20 sm:px-6">
+        <div className="flex items-center py-2">
+          <button
+            type="button"
+            onClick={() => {
+              if (window.history.length > 1) {
+                router.back();
+                return;
+              }
 
-          <div className="flex h-full w-full flex-col gap-4">
-            <InformationContainer
-              data={state.informationData}
-              viewType={viewType}
-              isLoggedIn={!!currentUser.id}
-              isParticipating={state.isParticipating}
-              onToggleLike={handleToggleMeetingLike}
-              onParticipateToggle={handleParticipateToggle}
-              onShare={handleShare}
-              onEdit={handleEdit}
-              onDelete={handleDelete}
-              onLoginAction={handleLoginAction}
-            />
+              router.push(ROUTES.search);
+            }}
+            className="flex h-9 w-9 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+            aria-label="뒤로가기"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        </div>
 
-            <PersonnelContainer data={state.personnelData} />
-          </div>
-        </section>
+        <div className="flex flex-col gap-12">
+          <section className="grid grid-cols-1 gap-4 md:grid-cols-[0.95fr_1.05fr] md:items-stretch">
+            <div className="relative aspect-[630/400] h-full w-full overflow-hidden rounded-[16px] md:rounded-[20px]">
+              {state.informationData.image ? (
+                <Image src={state.informationData.image} alt="모임 대표 이미지" fill className="object-cover" />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400 text-sm">
+                  이미지 영역
+                </div>
+              )}
+            </div>
 
-        <DescriptionSection description={initialDescription} />
+            <div className="flex h-full w-full flex-col gap-4">
+              <InformationContainer
+                data={state.informationData}
+                viewType={viewType}
+                isLoggedIn={!!currentUser.id}
+                isParticipating={state.isParticipating}
+                onToggleLike={handleToggleMeetingLike}
+                onParticipateToggle={handleParticipateToggle}
+                onShare={handleShare}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+                onLoginAction={handleLoginAction}
+              />
 
-        <section className="flex flex-col gap-4">
-          <h2 className="font-semibold text-black text-xl leading-[1.4]">이런 모임은 어때요?</h2>
+              <PersonnelContainer data={state.personnelData} />
+            </div>
+          </section>
 
-          <div className="grid grid-cols-2 gap-x-4 gap-y-4 xl:grid-cols-4">
-            {state.recommendedMeetings.map((meeting) => {
-              const isRecommendedLikePending = state.pendingRecommendedLikeIds.includes(meeting.id);
+          <DescriptionSection description={initialDescription} />
 
-              return (
-                <Link
-                  key={meeting.id}
-                  href={`${ROUTES.moimDetail}/${meeting.id}`}
-                  className="block cursor-pointer"
-                  onClick={(event) => {
-                    const target = event.target as HTMLElement;
+          <section className="flex flex-col gap-4">
+            <h2 className="font-semibold text-black text-xl leading-[1.4]">이런 모임은 어때요?</h2>
 
-                    if (target.closest("button")) {
-                      event.preventDefault();
-                    }
-                  }}
-                >
-                  <CompactCard
-                    image={
-                      meeting.image ? (
-                        <Image src={meeting.image} alt={meeting.title} fill className="object-cover" />
-                      ) : (
-                        <div className="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400 text-xs md:text-sm">
-                          이미지 영역
-                        </div>
-                      )
-                    }
-                    deadlineLabel={meeting.deadlineLabel}
-                    dateLabel={meeting.dateLabel}
-                    timeLabel={meeting.timeLabel}
-                    title={meeting.title}
-                    locationIcon={<LocationIcon />}
-                    locationText={meeting.locationText}
-                    isLiked={meeting.isLiked}
-                    onLike={() => {
-                      if (isRecommendedLikePending) {
-                        return false;
+            <div className="grid grid-cols-2 gap-x-4 gap-y-4 xl:grid-cols-4">
+              {state.recommendedMeetings.map((meeting) => {
+                const isRecommendedLikePending = state.pendingRecommendedLikeIds.includes(meeting.id);
+
+                return (
+                  <Link
+                    key={meeting.id}
+                    href={`${ROUTES.moimDetail}/${meeting.id}`}
+                    className="block cursor-pointer"
+                    onClick={(event) => {
+                      const target = event.target as HTMLElement;
+
+                      if (target.closest("button")) {
+                        event.preventDefault();
                       }
-
-                      return handleToggleRecommendedLike(meeting.id);
                     }}
-                  />
-                </Link>
-              );
-            })}
-          </div>
-        </section>
+                  >
+                    <CompactCard
+                      image={
+                        meeting.image ? (
+                          <Image src={meeting.image} alt={meeting.title} fill className="object-cover" />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center bg-gray-200 text-gray-400 text-xs md:text-sm">
+                            이미지 영역
+                          </div>
+                        )
+                      }
+                      deadlineLabel={meeting.deadlineLabel}
+                      dateLabel={meeting.dateLabel}
+                      timeLabel={meeting.timeLabel}
+                      title={meeting.title}
+                      locationIcon={<LocationIcon />}
+                      locationText={meeting.locationText}
+                      isLiked={meeting.isLiked}
+                      onLike={() => {
+                        if (isRecommendedLikePending) {
+                          return false;
+                        }
+
+                        return handleToggleRecommendedLike(meeting.id);
+                      }}
+                    />
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        </div>
       </main>
     </div>
   );

--- a/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
+++ b/apps/web/src/_pages/moim-detail/ui/moim-detail-client.tsx
@@ -260,11 +260,6 @@ export const MoimDetailClient = ({
           <button
             type="button"
             onClick={() => {
-              if (window.history.length > 1) {
-                router.back();
-                return;
-              }
-
               router.push(ROUTES.search);
             }}
             className="flex h-9 w-9 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"

--- a/apps/web/src/entities/moim-detail/model/mapper.ts
+++ b/apps/web/src/entities/moim-detail/model/mapper.ts
@@ -304,7 +304,7 @@ export function mapMeetingDetailToInformationData(params: {
     isLiked: getIsLiked(meeting),
     image: meeting.image ?? null,
     hostId: meeting.hostId,
-    hostName: meeting.host?.name ?? "알 수 없음",
+    hostName: meeting.host?.name?.trim() || "알 수 없음",
     hostImage: meeting.host?.image ?? null,
     viewerRole,
     isJoined,

--- a/apps/web/src/entities/moim-detail/model/mapper.ts
+++ b/apps/web/src/entities/moim-detail/model/mapper.ts
@@ -304,6 +304,8 @@ export function mapMeetingDetailToInformationData(params: {
     isLiked: getIsLiked(meeting),
     image: meeting.image ?? null,
     hostId: meeting.hostId,
+    hostName: meeting.host?.name ?? "알 수 없음",
+    hostImage: meeting.host?.image ?? null,
     viewerRole,
     isJoined,
     status,

--- a/apps/web/src/entities/moim-detail/model/types.ts
+++ b/apps/web/src/entities/moim-detail/model/types.ts
@@ -27,6 +27,8 @@ export interface InformationData {
   isLiked: boolean;
   image: string | null;
   hostId: number;
+  hostName: string;
+  hostImage: string | null;
   viewerRole: ViewerRole;
   isJoined: boolean;
   status: MeetingStatus;


### PR DESCRIPTION
## 📌 Summary
모임 상세 페이지 UX 개선을 위해 유저 피드백 3가지를 반영했습니다.

- close #217 

## 📄 Tasks
- 모임 신청 취소 시 확인 모달 추가
- 모임 상세에서 `/search` 페이지로 돌아가는 뒤로가기 버튼 추가
- 모임 설명 섹션에 주최자 정보 추가

## 👀 To Reviewer
- 기존에 모임 설명이 텍스트 위주로 구성되어 시각적 정보가 부족하다는 피드백이 있었습니다.
- 해시태그는 상단 모임 정보 섹션에서 이미 제공되고 있어, 설명 영역에는 주최자 정보를 추가하는 방향으로 보완했습니다.

## 📸 Screenshot
https://github.com/user-attachments/assets/ee19f9ca-97c9-448b-853f-abfe087199b8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 모임 상세 페이지에 매니저 정보 표시(이름, 프로필 이미지 및 이미지 미존재 시 이니셜 아바타)
  * 뒤로가기 네비게이션 추가
  * 신청 취소 시 확인 모달 추가
  * 미로그인 상태에서 참여 신청 시 로그인 모달 표시

* **Improvements**
  * 상세 설명 영역의 타이포그래피·스타일 정리 및 빈 설명 표시 개선
  * 추천 모임 좋아요 처리 및 버튼 호버/텍스트 스타일 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->