### PR TITLE
[fix] 잔디 연속 활동일수 버그 수정

### DIFF
--- a/apps/web/src/features/space/use-cases/get-member-grass.test.ts
+++ b/apps/web/src/features/space/use-cases/get-member-grass.test.ts
@@ -153,6 +153,25 @@ describe("getSpaceMemberGrassUseCase", () => {
       activeDays: 2,
     });
   });
+  it("어제와 오늘이 모두 비어 있으면 streak는 0일이다", async () => {
+    repository.countPostsByDateRange.setRows([
+      { date: "2026-04-06", count: 1 },
+      { date: "2026-04-07", count: 1 },
+    ]);
+
+    const useCase = createGetGrassUseCase({
+      repository,
+      getTodayDateKey: () => "2026-04-09",
+    });
+    const result = await useCase("space-1", 7, { days: 4 });
+
+    expect(result.summary).toEqual({
+      todayScore: 0,
+      currentStreak: 0,
+      recentScore: 4,
+      activeDays: 2,
+    });
+  });
 });
 
 const createCountStub = () => {

--- a/apps/web/src/features/space/use-cases/get-member-grass.ts
+++ b/apps/web/src/features/space/use-cases/get-member-grass.ts
@@ -156,23 +156,18 @@ const applyCounts = (
 };
 
 const getCurrentStreak = (days: GrassDay[]) => {
-  let latestActiveIndex = -1;
+  const todayIndex = days.length - 1;
+  const today = days[todayIndex];
+  const yesterday = days[todayIndex - 1];
+  const anchorIndex = today?.score > 0 ? todayIndex : yesterday?.score > 0 ? todayIndex - 1 : -1;
 
-  for (let index = days.length - 1; index >= 0; index -= 1) {
-    const day = days[index];
-    if (day && day.score > 0) {
-      latestActiveIndex = index;
-      break;
-    }
-  }
-
-  if (latestActiveIndex < 0) {
+  if (anchorIndex < 0) {
     return 0;
   }
 
   let streak = 0;
 
-  for (let index = latestActiveIndex; index >= 0; index -= 1) {
+  for (let index = anchorIndex; index >= 0; index -= 1) {
     const day = days[index];
     if (!day || day.score === 0) {
       break;


### PR DESCRIPTION
## 📌 Summary

잔디(활동 점수) 기능에서 `현재 연속 활동`(Current Streak)일수 계산되는 로직의 오류를 수정하였습니다. 활동이 이미 끊겼음에도 과거의 마지막 활동일부터 소급하여 계산되던 버그를 해결하고, 오늘과 어제를 기준으로 조금 더 엄격하게 연속 활동일수 계산 규칙을 적용했습니다.

- close #238 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks

- `현재 연속 활동`(Current Streak)일수 계산 로직 수정:

  - **anchor 기준점 도입**: 오늘 활동이 있으면 오늘부터, 오늘 없고 어제 있으면 어제부터 역산

  - **오늘과 어제 모두 활동이 없는 경우**, 이전 기록과 상관없이 스트릭을 0으로 처리하도록 변경

- 테스트 케이스 추가 및 검증:

  - get-member-grass.test.ts에 '어제와 오늘이 모두 비어 있는 경우'에 대한 테스트 시나리오 추가


## 👀 To Reviewer

_리뷰어에게 요청하는 내용을 작성해주세요._

- **수정 전** 3일 전까지의 날짜별 활동점수 조회 후:

  - 오늘 0(활동점수) / 어제 1 / 그제 1 / 3일전 1 -> **3일** (유지), **정상**

  - 오늘 0 / 어제 0 / 그제 1 / 3일전 1 -> **2일** (유지), **버그 발생**

  - 오늘 1 / 어제 0 / 그제 1 -> **1일** (새로 시작), **정상**
  
- **수정 후** 동작 예시:

  - 오늘 0 / 어제 1 / 그제 1 / 3일전 1 -> **3일** (유지), **정상**

  - 오늘 0 / 어제 0 / 그제 1 / 3일전 1 -> **0일** (중단됨), **정상, 수정 완료**

  - 오늘 1 / 어제 0 / 그제 1 -> **1일** (새로 시작), **정상**

## 📸 Screenshot


